### PR TITLE
feat: provision local PostgreSQL workflow for apps/api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+POSTGRES_DB=padel
+POSTGRES_USER=padel
+POSTGRES_PASSWORD=padel
+POSTGRES_PORT=5432
+NODE_ENV=development
+PORT=3000
+DATABASE_URL=postgresql://padel:padel@localhost:5432/padel?schema=public
+LOG_LEVEL=info
+LOG_JSON=false
+API_RATE_LIMIT_MAX=100
+API_RATE_LIMIT_TTL_MS=60000

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,12 +5,16 @@
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "db:up": "docker compose up -d postgres",
+    "db:down": "docker compose down",
     "lint": "biome check src/app.module.ts src/main.ts src/common src/competition src/prisma package.json tsconfig.json tsconfig.build.json",
     "prisma:generate": "pnpm -w exec prisma generate --schema ./apps/api/prisma/schema.prisma",
     "prisma:migrate:dev": "pnpm -w exec prisma migrate dev --schema ./apps/api/prisma/schema.prisma",
     "prisma:migrate:deploy": "pnpm -w exec prisma migrate deploy --schema ./apps/api/prisma/schema.prisma",
+    "prisma:migrate:status": "pnpm -w exec prisma migrate status --schema ./apps/api/prisma/schema.prisma",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:integration:db": "vitest run src/competition/outbound/persistence/prisma-competition.repository.test.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.1.8",

--- a/apps/api/prisma/migrations/20260428193000_init_competition/migration.sql
+++ b/apps/api/prisma/migrations/20260428193000_init_competition/migration.sql
@@ -1,0 +1,20 @@
+-- CreateEnum
+CREATE TYPE "CompetitionFormat" AS ENUM ('elimination', 'round_robin', 'league');
+
+-- CreateEnum
+CREATE TYPE "CompetitionStatus" AS ENUM ('draft', 'open', 'closed');
+
+-- CreateTable
+CREATE TABLE "Competition" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "format" "CompetitionFormat" NOT NULL,
+    "startsAt" TIMESTAMP(3) NOT NULL,
+    "endsAt" TIMESTAMP(3) NOT NULL,
+    "ownerId" TEXT NOT NULL,
+    "status" "CompetitionStatus" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Competition_pkey" PRIMARY KEY ("id")
+);

--- a/apps/api/prisma/migrations/migration_lock.toml
+++ b/apps/api/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/apps/api/src/competition/outbound/persistence/prisma-competition.repository.test.ts
+++ b/apps/api/src/competition/outbound/persistence/prisma-competition.repository.test.ts
@@ -1,4 +1,7 @@
+import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -8,39 +11,41 @@ import { PrismaCompetitionRepository } from "./prisma-competition.repository.js"
 
 const databaseUrl = process.env.DATABASE_URL;
 const canRunDatabaseTests = Boolean(databaseUrl);
+const repositoryRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../../..",
+);
+
+function applyPrismaMigrations() {
+  const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+  execFileSync(
+    pnpmCommand,
+    [
+      "-w",
+      "exec",
+      "prisma",
+      "migrate",
+      "deploy",
+      "--schema",
+      "./apps/api/prisma/schema.prisma",
+    ],
+    {
+      cwd: repositoryRoot,
+      env: process.env,
+      stdio: "inherit",
+    },
+  );
+}
 
 describe.skipIf(!canRunDatabaseTests)("PrismaCompetitionRepository", () => {
   let prisma: PrismaService;
 
   beforeAll(async () => {
+    applyPrismaMigrations();
+
     prisma = new PrismaService();
     await prisma.$connect();
-
-    await prisma
-      .$executeRawUnsafe(`
-      CREATE TYPE "CompetitionFormat" AS ENUM ('elimination', 'round_robin', 'league');
-    `)
-      .catch(() => undefined);
-
-    await prisma
-      .$executeRawUnsafe(`
-      CREATE TYPE "CompetitionStatus" AS ENUM ('draft', 'open', 'closed');
-    `)
-      .catch(() => undefined);
-
-    await prisma.$executeRawUnsafe(`
-      CREATE TABLE IF NOT EXISTS "Competition" (
-        "id" TEXT PRIMARY KEY,
-        "title" TEXT NOT NULL,
-        "format" "CompetitionFormat" NOT NULL,
-        "startsAt" TIMESTAMPTZ NOT NULL,
-        "endsAt" TIMESTAMPTZ NOT NULL,
-        "ownerId" TEXT NOT NULL,
-        "status" "CompetitionStatus" NOT NULL,
-        "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-        "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
-      );
-    `);
 
     await prisma.competition.deleteMany();
   });

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,22 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: padel-postgres
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-padel}
+      POSTGRES_USER: ${POSTGRES_USER:-padel}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-padel}
+      PGDATA: /var/lib/postgresql/data/pgdata
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+    volumes:
+      - padel-postgres-data:/var/lib/postgresql/data
+
+volumes:
+  padel-postgres-data:

--- a/docs/09-agile/product-backlog.md
+++ b/docs/09-agile/product-backlog.md
@@ -246,7 +246,7 @@ For each ticket, include:
   - integration: verify Prisma migration and repository tests can run against the Docker-backed PostgreSQL instance
   - e2e/manual: manually confirm a developer can start the local database and connect `apps/api` successfully
 - estimate: `M`
-- status: `approved`
+- status: `done`
 - implementation workflow: `backend`
 - GitHub labels: `type:task`, `lane:infrastructure`, `area:platform`, `area:data`, `target:apps-api`
 - milestone/sprint: `next-foundation-sprint`

--- a/docs/09-agile/sprint-backlog.md
+++ b/docs/09-agile/sprint-backlog.md
@@ -21,9 +21,19 @@ If this document and the GitHub Project disagree, update both and record the rea
 
 ## Current State
 
-- No active sprint backlog is committed yet for the next implementation wave.
 - `TKT-010`, `TKT-011` and `TKT-012` are delivered on `master` and should be treated as completed foundation work rather than open sprint candidates.
 - `TKT-013` is completed through `ADR-010`.
 - `TKT-014` is delivered as the first backend implementation slice for competition creation under `CORE-01`.
-- The next recommended infrastructure ticket is `TKT-015`, provisioning local PostgreSQL with Docker for Prisma and Nest integration.
+- `TKT-015` is delivered as the local PostgreSQL infrastructure path for Prisma, NestJS integration, and repository-backed database tests.
 - The next recommended backend ticket after that is `TKT-016`, establishing the Better Auth foundation.
+
+## Active Sprint Record
+
+- ticket ID and title: `TKT-015` - Provision local PostgreSQL with Docker for Prisma and Nest integration
+- delivery lane: `infrastructure`
+- affected apps/packages: `apps/api`
+- owner: `unassigned`
+- GitHub issue link: `https://github.com/Damimd10/padel/issues/14`
+- current project status: `done`
+- blocked/unblocked state: `unblocked`
+- notes for carryover risk: `none; Better Auth foundation now depends on the delivered local PostgreSQL workflow instead of a remote/shared database`

--- a/docs/09-agile/sprint-plan.md
+++ b/docs/09-agile/sprint-plan.md
@@ -33,22 +33,21 @@ Every committed ticket must:
 - sprint dates or iteration label: `next-foundation-sprint`
 - capacity assumptions:
   - monorepo, UI foundation, Storybook bootstrap, backend persistence, and the first competition-create backend slice are already delivered or accepted on `master`
-  - the next delivery bottlenecks are local PostgreSQL infrastructure and authentication foundation, not another create-competition backend slice
+  - local PostgreSQL infrastructure is now delivered, and the next delivery bottleneck is the Better Auth foundation rather than another create-competition backend slice
 - committed tickets:
-  - none yet; the next candidates should be `TKT-015` and `TKT-016`
-- stretch tickets:
   - `TKT-015` - provision local PostgreSQL with Docker for Prisma and Nest integration
+- stretch tickets:
   - `TKT-016` - establish Better Auth foundation for application authentication
 - lane balance across frontend / backend / infrastructure:
-  - infrastructure: `TKT-015`
+  - infrastructure: delivered through `TKT-015`
   - frontend: completed foundation work only
   - backend: `TKT-016`
 - affected apps/packages summary:
   - `TKT-015`: `apps/api`
   - `TKT-016`: `apps/api`, `apps/web`
 - dependencies and blockers:
-  - `TKT-015` unblocks a reproducible local PostgreSQL path for Prisma migrations, repository tests, and Better Auth persistence
-  - `TKT-016` should follow `ADR-011` and is safer once `TKT-015` exists
+  - `TKT-015` delivered the reproducible local PostgreSQL path for Prisma migrations, repository tests, and Better Auth persistence
+  - `TKT-016` should follow `ADR-011` and now builds on the local PostgreSQL workflow delivered in `TKT-015`
 - GitHub milestone / project view used for execution:
   - milestone: `next-foundation-sprint`
   - project status: sync after GitHub Issues are created
@@ -56,4 +55,5 @@ Every committed ticket must:
   - completed foundation tickets are reflected as delivered in backlog and GitHub
   - `TKT-013` is closed with the accepted persistence ADR linked
   - `TKT-014` is reflected as delivered in backlog and GitHub
-  - `TKT-015` and `TKT-016` exist as GitHub Issues without reopening the already accepted Prisma or Better Auth tool choices
+  - `TKT-015` is reflected as delivered in backlog and GitHub without reopening the accepted Prisma choice
+  - `TKT-016` exists as a GitHub Issue without reopening the accepted Better Auth choice

--- a/docs/13-testing/integration-testing.md
+++ b/docs/13-testing/integration-testing.md
@@ -10,6 +10,12 @@ Integration tests validate the "seams" of the application where different module
 - **Inbound Adapters**: Test NestJS Controllers using `supertest` to verify routing, guards, and status code mapping.
 - **Transaction Management**: Verify that unit-of-work/transaction decorators correctly commit or rollback changes.
 
+#### Current local baseline for `apps/api`
+
+- The default repository-backed database path is the checked-in Docker Compose PostgreSQL service at the repository root.
+- Developers should boot PostgreSQL with `pnpm run db:up`, configure `DATABASE_URL` from `.env.example`, and apply Prisma migrations with `pnpm --filter @padel/api prisma:migrate:deploy`.
+- The Prisma repository integration test is exercised with `pnpm --filter @padel/api test:integration:db` and should rely on the checked-in Prisma migration history rather than custom schema bootstrapping inside the test.
+
 ### Frontend Integration (Route & Data)
 - **TanStack Router + Query**: Test that navigating to a route triggers the correct query and renders the data.
 - **Form Submission**: Test the full cycle of user input -> TanStack Form validation -> TanStack Query mutation -> Cache invalidation.
@@ -22,3 +28,4 @@ Integration tests validate the "seams" of the application where different module
 ### Rules
 - **No Manual Mocks for DB**: Always use a real database for repository tests.
 - **Isolation**: Each test must run in a clean transaction or have its data purged via `TRUNCATE`.
+- **Migration Fidelity**: Integration tests that hit PostgreSQL should prepare schema state through Prisma migrations so test setup matches the runtime persistence path.

--- a/docs/15-developer-experience/local-development.md
+++ b/docs/15-developer-experience/local-development.md
@@ -7,10 +7,84 @@ Define the local developer workflow before implementation begins.
 ## Expected local flow
 
 1. install with `pnpm`
-2. run workspace tasks through Nx
-3. rely on Biome for source hygiene
-4. use Lefthook for commit-time validation
-5. run affected tests before pushing
+2. copy `.env.example` to `.env` and set local values before starting backend work
+3. boot local infrastructure through the checked-in Docker workflow
+4. run workspace tasks through Nx
+5. rely on Biome for source hygiene
+6. use Lefthook for commit-time validation
+7. run affected tests before pushing
+
+## Local PostgreSQL for `apps/api`
+
+`TKT-015` establishes the default local PostgreSQL path for Prisma, NestJS runtime development, repository integration tests, and future Better Auth persistence.
+
+### Standard environment
+
+Create a local `.env` from the checked-in template:
+
+```bash
+cp .env.example .env
+```
+
+Use this baseline connection string unless you intentionally change the Docker service settings:
+
+```bash
+POSTGRES_DB=padel
+POSTGRES_USER=padel
+POSTGRES_PASSWORD=padel
+POSTGRES_PORT=5432
+DATABASE_URL=postgresql://padel:padel@localhost:5432/padel?schema=public
+```
+
+If your machine already uses port `5432`, set a different `POSTGRES_PORT` and keep `DATABASE_URL` aligned with the same port.
+
+### Boot the database
+
+From the repository root:
+
+```bash
+pnpm run db:up
+```
+
+Useful companion commands:
+
+```bash
+pnpm run db:ps
+pnpm run db:logs
+pnpm run db:down
+```
+
+The checked-in compose file provisions a single local PostgreSQL 16 container named `padel-postgres` with a persistent Docker volume. It reads `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_PORT` from `.env` so local developers can resolve port collisions without editing committed infrastructure files.
+
+### Prisma workflow for `apps/api`
+
+Generate the Prisma client after schema changes:
+
+```bash
+pnpm --filter @padel/api prisma:generate
+```
+
+Apply the checked-in migrations to the local database:
+
+```bash
+pnpm --filter @padel/api prisma:migrate:deploy
+```
+
+Create and apply a new local development migration when an approved backend ticket changes the Prisma schema:
+
+```bash
+pnpm --filter @padel/api prisma:migrate:dev --name <migration-name>
+```
+
+### Integration-test workflow
+
+With PostgreSQL running and `DATABASE_URL` configured, the Prisma repository integration test can run against the real local database:
+
+```bash
+pnpm --filter @padel/api test:integration:db
+```
+
+That test applies checked-in Prisma migrations before executing the repository assertions, so it validates the same schema path used by local NestJS development.
 
 ## Principle
 

--- a/docs/16-backend-architecture/database-strategy.md
+++ b/docs/16-backend-architecture/database-strategy.md
@@ -7,3 +7,16 @@
 - transaction strategy should be explicit at the application layer
 - migration and operational concerns should not distort domain boundaries
 - the concrete persistence implementation approach is defined in `/docs/07-adrs/adr-010-backend-persistence-implementation.md`, using Prisma as the accepted adapter-layer ORM
+
+## Local infrastructure baseline
+
+- `apps/api` uses the checked-in repository `compose.yaml` as the default local PostgreSQL workflow for backend delivery
+- local Prisma and NestJS development use `DATABASE_URL=postgresql://padel:padel@localhost:5432/padel?schema=public` unless a developer intentionally overrides the compose settings
+- local port or credential overrides must flow through `.env` so the checked-in infrastructure stays shared while each developer can resolve host-specific conflicts
+- the local database setup must stay generic enough to support future Prisma-managed application tables and Better Auth persistence tables without introducing authentication-specific code in infrastructure tickets
+
+## Migration policy
+
+- Prisma migrations under `apps/api/prisma/migrations` are the canonical database-change history for local and CI-compatible backend setup
+- repository integration tests should validate adapters against schema state produced by Prisma migrations instead of hand-written ad hoc table creation
+- schema changes for backend tickets must land with updated migration files, regenerated Prisma client output, and matching documentation updates when the workflow changes

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "packageManager": "pnpm@10.6.3",
   "scripts": {
     "prepare": "lefthook install",
+    "db:up": "docker compose up -d postgres",
+    "db:down": "docker compose down",
+    "db:logs": "docker compose logs -f postgres",
+    "db:ps": "docker compose ps",
     "build": "pnpm exec nx run-many -t build --all",
     "build:affected": "pnpm exec nx affected -t build --base=origin/main --head=HEAD",
     "boundaries": "node scripts/check-module-boundaries.mjs",


### PR DESCRIPTION
## Summary
- add a checked-in Docker Compose PostgreSQL workflow for `apps/api`
- add `.env.example`, Prisma migration history, and repository scripts for local Prisma/Nest usage
- document the local DB, `DATABASE_URL`, Prisma generate/migrate flow, and integration-test path in DX/backend/agile docs
- update the Prisma repository integration test to apply checked-in migrations instead of creating schema objects ad hoc

## Validation
- `pnpm run boundaries`
- `DATABASE_URL=postgresql://padel:padel@localhost:5433/padel?schema=public pnpm --filter @padel/api prisma:generate`
- `DATABASE_URL=postgresql://padel:padel@localhost:5433/padel?schema=public pnpm --filter @padel/api prisma:migrate:deploy`
- `DATABASE_URL=postgresql://padel:padel@localhost:5433/padel?schema=public pnpm --filter @padel/api prisma:migrate:status`
- `DATABASE_URL=postgresql://padel:padel@localhost:5433/padel?schema=public pnpm --filter @padel/api test:integration:db`
- `DATABASE_URL=postgresql://padel:padel@localhost:5433/padel?schema=public pnpm exec nx run-many -t lint,typecheck,test,build --projects=@padel/api`
- `DATABASE_URL=postgresql://padel:padel@localhost:5433/padel?schema=public pnpm exec nx affected -t lint,typecheck,test,build --base="$(git merge-base origin/master HEAD)" --head=HEAD`
- `git push -u origin codex/issue-14-postgres-docker` pre-push hook: `nx affected -t lint,typecheck,test,build` + `pnpm run boundaries`

## Notes
- The exact requested `origin/main` affected command is not runnable in this repository because the remote default branch is `master`, so the equivalent validation was executed against `origin/master`.
- Local PostgreSQL port conflicts are handled through `.env` overrides such as `POSTGRES_PORT=5433`, keeping the checked-in Docker setup reusable without editing committed files.

Closes #14