### PR TITLE
feat(api): require authenticated identity for competition creation

### DIFF
--- a/apps/api/src/common/modules/auth/application/ports/auth-gateway.port.ts
+++ b/apps/api/src/common/modules/auth/application/ports/auth-gateway.port.ts
@@ -6,7 +6,11 @@ import type {
 
 export interface AuthSession {
   session: Record<string, unknown>;
-  user: Record<string, unknown>;
+  user: AuthenticatedUser;
+}
+
+export interface AuthenticatedUser extends Record<string, unknown> {
+  id: string;
 }
 
 export interface AuthGateway {

--- a/apps/api/src/competition/application/create-competition.command.ts
+++ b/apps/api/src/competition/application/create-competition.command.ts
@@ -1,5 +1,5 @@
-import { createCompetitionRequestSchema } from "@padel/schemas";
-import { z } from "zod";
+import type { createCompetitionRequestSchema } from "@padel/schemas";
+import type { z } from "zod";
 
 type CreateCompetitionRequest = z.infer<typeof createCompetitionRequestSchema>;
 

--- a/apps/api/src/competition/application/create-competition.command.ts
+++ b/apps/api/src/competition/application/create-competition.command.ts
@@ -1,0 +1,8 @@
+import { createCompetitionRequestSchema } from "@padel/schemas";
+import { z } from "zod";
+
+type CreateCompetitionRequest = z.infer<typeof createCompetitionRequestSchema>;
+
+export interface CreateCompetitionCommand extends CreateCompetitionRequest {
+  ownerId: string;
+}

--- a/apps/api/src/competition/application/create-competition.use-case.test.ts
+++ b/apps/api/src/competition/application/create-competition.use-case.test.ts
@@ -1,14 +1,11 @@
 import { describe, expect, it } from "vitest";
 
+import type { CreateCompetitionCommand } from "./create-competition.command.js";
 import { CreateCompetitionUseCase } from "./create-competition.use-case.js";
 import type { CompetitionRepository } from "./ports/competition-repository.js";
 
 class FakeCompetitionRepository implements CompetitionRepository {
-  created: ReturnType<
-    InstanceType<typeof CreateCompetitionUseCase>["execute"]
-  > extends Promise<infer _>
-    ? unknown[]
-    : never = [];
+  created: unknown[] = [];
 
   async nextId() {
     return "competition-123";
@@ -32,7 +29,7 @@ describe("CreateCompetitionUseCase", () => {
       startsAt: "2026-05-10T10:00:00.000Z",
       endsAt: "2026-05-12T18:00:00.000Z",
       ownerId: "owner-99",
-    });
+    } satisfies CreateCompetitionCommand);
 
     expect(result).toMatchObject({
       id: "competition-123",

--- a/apps/api/src/competition/application/create-competition.use-case.ts
+++ b/apps/api/src/competition/application/create-competition.use-case.ts
@@ -1,10 +1,8 @@
 import { Inject, Injectable } from "@nestjs/common";
-import type {
-  CreateCompetitionInput,
-  CreateCompetitionResponse,
-} from "@padel/schemas";
+import type { CreateCompetitionResponse } from "@padel/schemas";
 
 import { Competition } from "../domain/competition.js";
+import type { CreateCompetitionCommand } from "./create-competition.command.js";
 import {
   type CompetitionRepository,
   CompetitionRepositoryToken,
@@ -18,7 +16,7 @@ export class CreateCompetitionUseCase {
   ) {}
 
   async execute(
-    input: CreateCompetitionInput,
+    input: CreateCompetitionCommand,
   ): Promise<CreateCompetitionResponse> {
     const id = await this.competitionRepository.nextId();
     const competition = Competition.createDraft(input, id);

--- a/apps/api/src/competition/domain/competition.ts
+++ b/apps/api/src/competition/domain/competition.ts
@@ -1,9 +1,9 @@
+import type { CreateCompetitionCommand } from "../application/create-competition.command.js";
 import {
   type CompetitionFormat,
   assertCompetitionFormat,
 } from "./competition-format.js";
 import { draftCompetitionStatus } from "./competition-status.js";
-import type { CreateCompetitionCommand } from "../application/create-competition.command.js";
 
 export interface CompetitionProps {
   id: string;

--- a/apps/api/src/competition/domain/competition.ts
+++ b/apps/api/src/competition/domain/competition.ts
@@ -1,10 +1,9 @@
-import type { CreateCompetitionInput } from "@padel/schemas";
-
 import {
   type CompetitionFormat,
   assertCompetitionFormat,
 } from "./competition-format.js";
 import { draftCompetitionStatus } from "./competition-status.js";
+import type { CreateCompetitionCommand } from "../application/create-competition.command.js";
 
 export interface CompetitionProps {
   id: string;
@@ -19,7 +18,7 @@ export interface CompetitionProps {
 export class Competition {
   private constructor(private readonly props: CompetitionProps) {}
 
-  static createDraft(input: CreateCompetitionInput, id: string) {
+  static createDraft(input: CreateCompetitionCommand, id: string) {
     const title = input.title.trim();
     const ownerId = input.ownerId.trim();
 

--- a/apps/api/src/competition/inbound/http/competition.controller.integration.test.ts
+++ b/apps/api/src/competition/inbound/http/competition.controller.integration.test.ts
@@ -40,101 +40,104 @@ function applyPrismaMigrations() {
   );
 }
 
-describe.skipIf(!canRunDatabaseTests)("CompetitionController integration", () => {
-  let prisma: PrismaService;
-  let app: INestApplication;
+describe.skipIf(!canRunDatabaseTests)(
+  "CompetitionController integration",
+  () => {
+    let prisma: PrismaService;
+    let app: INestApplication;
 
-  beforeAll(async () => {
-    process.env.NODE_ENV ??= "test";
-    process.env.BETTER_AUTH_SECRET ??= "test-secret";
-    process.env.BETTER_AUTH_URL ??= "http://localhost:3000";
-    process.env.LOG_LEVEL ??= "error";
-    process.env.LOG_JSON ??= "true";
-    process.env.API_RATE_LIMIT_MAX ??= "100";
-    process.env.API_RATE_LIMIT_TTL_MS ??= "60000";
+    beforeAll(async () => {
+      process.env.NODE_ENV ??= "test";
+      process.env.BETTER_AUTH_SECRET ??= "test-secret";
+      process.env.BETTER_AUTH_URL ??= "http://localhost:3000";
+      process.env.LOG_LEVEL ??= "error";
+      process.env.LOG_JSON ??= "true";
+      process.env.API_RATE_LIMIT_MAX ??= "100";
+      process.env.API_RATE_LIMIT_TTL_MS ??= "60000";
 
-    applyPrismaMigrations();
+      applyPrismaMigrations();
 
-    prisma = new PrismaService();
-    await prisma.$connect();
+      prisma = new PrismaService();
+      await prisma.$connect();
 
-    await prisma.competition.deleteMany();
-    await prisma.session.deleteMany();
-    await prisma.account.deleteMany();
-    await prisma.user.deleteMany();
-    await prisma.verification.deleteMany();
+      await prisma.competition.deleteMany();
+      await prisma.session.deleteMany();
+      await prisma.account.deleteMany();
+      await prisma.user.deleteMany();
+      await prisma.verification.deleteMany();
 
-    const { createApp } = await import("../../../main.js");
+      const { createApp } = await import("../../../main.js");
 
-    app = await createApp();
-    await app.init();
-  });
+      app = await createApp();
+      await app.init();
+    });
 
-  afterAll(async () => {
-    await app?.close();
-    await prisma?.$disconnect();
-  });
+    afterAll(async () => {
+      await app?.close();
+      await prisma?.$disconnect();
+    });
 
-  it("rejects unauthenticated competition creation requests", async () => {
-    await request(app.getHttpServer())
-      .post("/competitions")
-      .send({
-        title: "Protected Open",
-        format: "elimination",
-        startsAt: "2026-05-10T10:00:00.000Z",
-        endsAt: "2026-05-12T18:00:00.000Z",
-      })
-      .expect(401)
-      .expect(({ body }: { body: unknown }) => {
-        expect(body).toMatchObject({
-          statusCode: 401,
-          message: "Unauthorized",
-          path: "/competitions",
+    it("rejects unauthenticated competition creation requests", async () => {
+      await request(app.getHttpServer())
+        .post("/competitions")
+        .send({
+          title: "Protected Open",
+          format: "elimination",
+          startsAt: "2026-05-10T10:00:00.000Z",
+          endsAt: "2026-05-12T18:00:00.000Z",
+        })
+        .expect(401)
+        .expect(({ body }: { body: unknown }) => {
+          expect(body).toMatchObject({
+            statusCode: 401,
+            message: "Unauthorized",
+            path: "/competitions",
+          });
         });
-      });
-  });
+    });
 
-  it("creates a competition for the authenticated user without requiring ownerId in the request", async () => {
-    const agent = request.agent(app.getHttpServer());
-    const email = `competition-${randomUUID()}@example.com`;
+    it("creates a competition for the authenticated user without requiring ownerId in the request", async () => {
+      const agent = request.agent(app.getHttpServer());
+      const email = `competition-${randomUUID()}@example.com`;
 
-    const signUpResponse = await agent
-      .post("/auth/sign-up/email")
-      .set("origin", "http://localhost:3000")
-      .send({
-        name: "Competition Test User",
-        email,
-        password: "password-1234",
-      })
-      .expect(200);
+      const signUpResponse = await agent
+        .post("/auth/sign-up/email")
+        .set("origin", "http://localhost:3000")
+        .send({
+          name: "Competition Test User",
+          email,
+          password: "password-1234",
+        })
+        .expect(200);
 
-    const authenticatedUserId = signUpResponse.body.user.id as string;
+      const authenticatedUserId = signUpResponse.body.user.id as string;
 
-    const response = await agent
-      .post("/competitions")
-      .send({
+      const response = await agent
+        .post("/competitions")
+        .send({
+          title: "Protected Open",
+          format: "elimination",
+          startsAt: "2026-05-10T10:00:00.000Z",
+          endsAt: "2026-05-12T18:00:00.000Z",
+        })
+        .expect(201);
+
+      expect(response.body).toMatchObject({
         title: "Protected Open",
         format: "elimination",
-        startsAt: "2026-05-10T10:00:00.000Z",
-        endsAt: "2026-05-12T18:00:00.000Z",
-      })
-      .expect(201);
+        ownerId: authenticatedUserId,
+        status: "draft",
+      });
 
-    expect(response.body).toMatchObject({
-      title: "Protected Open",
-      format: "elimination",
-      ownerId: authenticatedUserId,
-      status: "draft",
-    });
+      const competition = await prisma.competition.findUniqueOrThrow({
+        where: { id: response.body.id as string },
+      });
 
-    const competition = await prisma.competition.findUniqueOrThrow({
-      where: { id: response.body.id as string },
+      expect(competition).toMatchObject({
+        title: "Protected Open",
+        ownerId: authenticatedUserId,
+        status: "draft",
+      });
     });
-
-    expect(competition).toMatchObject({
-      title: "Protected Open",
-      ownerId: authenticatedUserId,
-      status: "draft",
-    });
-  });
-});
+  },
+);

--- a/apps/api/src/competition/inbound/http/competition.controller.integration.test.ts
+++ b/apps/api/src/competition/inbound/http/competition.controller.integration.test.ts
@@ -1,0 +1,140 @@
+import "reflect-metadata";
+
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { INestApplication } from "@nestjs/common";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { PrismaService } from "../../../prisma/prisma.service.js";
+
+const databaseUrl = process.env.DATABASE_URL;
+const canRunDatabaseTests = Boolean(databaseUrl);
+const repositoryRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../../..",
+);
+
+function applyPrismaMigrations() {
+  const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+  execFileSync(
+    pnpmCommand,
+    [
+      "-w",
+      "exec",
+      "prisma",
+      "migrate",
+      "deploy",
+      "--schema",
+      "./apps/api/prisma/schema.prisma",
+    ],
+    {
+      cwd: repositoryRoot,
+      env: process.env,
+      stdio: "inherit",
+    },
+  );
+}
+
+describe.skipIf(!canRunDatabaseTests)("CompetitionController integration", () => {
+  let prisma: PrismaService;
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV ??= "test";
+    process.env.BETTER_AUTH_SECRET ??= "test-secret";
+    process.env.BETTER_AUTH_URL ??= "http://localhost:3000";
+    process.env.LOG_LEVEL ??= "error";
+    process.env.LOG_JSON ??= "true";
+    process.env.API_RATE_LIMIT_MAX ??= "100";
+    process.env.API_RATE_LIMIT_TTL_MS ??= "60000";
+
+    applyPrismaMigrations();
+
+    prisma = new PrismaService();
+    await prisma.$connect();
+
+    await prisma.competition.deleteMany();
+    await prisma.session.deleteMany();
+    await prisma.account.deleteMany();
+    await prisma.user.deleteMany();
+    await prisma.verification.deleteMany();
+
+    const { createApp } = await import("../../../main.js");
+
+    app = await createApp();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    await prisma?.$disconnect();
+  });
+
+  it("rejects unauthenticated competition creation requests", async () => {
+    await request(app.getHttpServer())
+      .post("/competitions")
+      .send({
+        title: "Protected Open",
+        format: "elimination",
+        startsAt: "2026-05-10T10:00:00.000Z",
+        endsAt: "2026-05-12T18:00:00.000Z",
+      })
+      .expect(401)
+      .expect(({ body }: { body: unknown }) => {
+        expect(body).toMatchObject({
+          statusCode: 401,
+          message: "Unauthorized",
+          path: "/competitions",
+        });
+      });
+  });
+
+  it("creates a competition for the authenticated user without requiring ownerId in the request", async () => {
+    const agent = request.agent(app.getHttpServer());
+    const email = `competition-${randomUUID()}@example.com`;
+
+    const signUpResponse = await agent
+      .post("/auth/sign-up/email")
+      .set("origin", "http://localhost:3000")
+      .send({
+        name: "Competition Test User",
+        email,
+        password: "password-1234",
+      })
+      .expect(200);
+
+    const authenticatedUserId = signUpResponse.body.user.id as string;
+
+    const response = await agent
+      .post("/competitions")
+      .send({
+        title: "Protected Open",
+        format: "elimination",
+        startsAt: "2026-05-10T10:00:00.000Z",
+        endsAt: "2026-05-12T18:00:00.000Z",
+      })
+      .expect(201);
+
+    expect(response.body).toMatchObject({
+      title: "Protected Open",
+      format: "elimination",
+      ownerId: authenticatedUserId,
+      status: "draft",
+    });
+
+    const competition = await prisma.competition.findUniqueOrThrow({
+      where: { id: response.body.id as string },
+    });
+
+    expect(competition).toMatchObject({
+      title: "Protected Open",
+      ownerId: authenticatedUserId,
+      status: "draft",
+    });
+  });
+});

--- a/apps/api/src/competition/inbound/http/competition.controller.test.ts
+++ b/apps/api/src/competition/inbound/http/competition.controller.test.ts
@@ -1,15 +1,17 @@
 import "reflect-metadata";
 
+import { UnauthorizedException } from "@nestjs/common";
 import { ExpressAdapter } from "@nestjs/platform-express";
 import { Test } from "@nestjs/testing";
 import request from "supertest";
 import { describe, expect, it } from "vitest";
 
+import { AuthenticatedGuard } from "../../../common/modules/auth/inbound/http/authenticated.guard.js";
 import { CreateCompetitionUseCase } from "../../application/create-competition.use-case.js";
 import { CompetitionController } from "./competition.controller.js";
 
 describe("CompetitionController", () => {
-  it("creates a competition through the HTTP boundary", async () => {
+  it("creates a competition through the authenticated HTTP boundary", async () => {
     const moduleRef = await Test.createTestingModule({
       controllers: [CompetitionController],
       providers: [
@@ -30,7 +32,17 @@ describe("CompetitionController", () => {
           },
         },
       ],
-    }).compile();
+    })
+      .overrideGuard(AuthenticatedGuard)
+      .useValue({
+        canActivate(context: {
+          switchToHttp(): { getRequest(): { user?: { id: string } } };
+        }) {
+          context.switchToHttp().getRequest().user = { id: "user-1" };
+          return true;
+        },
+      })
+      .compile();
 
     const app = moduleRef.createNestApplication(new ExpressAdapter());
     await app.init();
@@ -42,7 +54,6 @@ describe("CompetitionController", () => {
         format: "elimination",
         startsAt: "2026-05-10T10:00:00.000Z",
         endsAt: "2026-05-12T18:00:00.000Z",
-        ownerId: "owner-1",
       })
       .expect(201)
       .expect(({ body }: { body: unknown }) => {
@@ -50,10 +61,48 @@ describe("CompetitionController", () => {
           id: "11111111-1111-4111-8111-111111111111",
           title: "Winter Open",
           format: "elimination",
-          ownerId: "owner-1",
+          ownerId: "user-1",
           status: "draft",
         });
       });
+
+    await app.close();
+  });
+
+  it("rejects unauthenticated requests before the use case runs", async () => {
+    const execute = () => {
+      throw new Error("should not be called");
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [CompetitionController],
+      providers: [
+        {
+          provide: CreateCompetitionUseCase,
+          useValue: { execute },
+        },
+      ],
+    })
+      .overrideGuard(AuthenticatedGuard)
+      .useValue({
+        canActivate() {
+          throw new UnauthorizedException();
+        },
+      })
+      .compile();
+
+    const app = moduleRef.createNestApplication(new ExpressAdapter());
+    await app.init();
+
+    await request(app.getHttpServer())
+      .post("/competitions")
+      .send({
+        title: "Winter Open",
+        format: "elimination",
+        startsAt: "2026-05-10T10:00:00.000Z",
+        endsAt: "2026-05-12T18:00:00.000Z",
+      })
+      .expect(401);
 
     await app.close();
   });

--- a/apps/api/src/competition/inbound/http/competition.controller.ts
+++ b/apps/api/src/competition/inbound/http/competition.controller.ts
@@ -13,8 +13,8 @@ import {
 } from "@padel/schemas";
 
 import type { AuthenticatedUser } from "../../../common/modules/auth/application/ports/auth-gateway.port.js";
-import { CurrentUser } from "../../../common/modules/auth/inbound/http/current-user.decorator.js";
 import { AuthenticatedGuard } from "../../../common/modules/auth/inbound/http/authenticated.guard.js";
+import { CurrentUser } from "../../../common/modules/auth/inbound/http/current-user.decorator.js";
 import { CreateCompetitionUseCase } from "../../application/create-competition.use-case.js";
 import { mapCreateCompetitionRequestToCommand } from "./create-competition-request.mapper.js";
 

--- a/apps/api/src/competition/inbound/http/competition.controller.ts
+++ b/apps/api/src/competition/inbound/http/competition.controller.ts
@@ -5,14 +5,18 @@ import {
   HttpStatus,
   Inject,
   Post,
+  UseGuards,
 } from "@nestjs/common";
 import {
-  type CreateCompetitionInput,
   createCompetitionRequestSchema,
   createCompetitionResponseSchema,
 } from "@padel/schemas";
 
+import type { AuthenticatedUser } from "../../../common/modules/auth/application/ports/auth-gateway.port.js";
+import { CurrentUser } from "../../../common/modules/auth/inbound/http/current-user.decorator.js";
+import { AuthenticatedGuard } from "../../../common/modules/auth/inbound/http/authenticated.guard.js";
 import { CreateCompetitionUseCase } from "../../application/create-competition.use-case.js";
+import { mapCreateCompetitionRequestToCommand } from "./create-competition-request.mapper.js";
 
 @Controller("competitions")
 export class CompetitionController {
@@ -22,10 +26,14 @@ export class CompetitionController {
   ) {}
 
   @Post()
+  @UseGuards(AuthenticatedGuard)
   @HttpCode(HttpStatus.CREATED)
-  async createCompetition(@Body() body: unknown) {
-    const input: CreateCompetitionInput =
-      createCompetitionRequestSchema.parse(body);
+  async createCompetition(
+    @Body() body: unknown,
+    @CurrentUser() user: AuthenticatedUser | undefined,
+  ) {
+    const request = createCompetitionRequestSchema.parse(body);
+    const input = mapCreateCompetitionRequestToCommand(request, user);
 
     const response = await this.createCompetitionUseCase.execute(input);
 

--- a/apps/api/src/competition/inbound/http/create-competition-request.mapper.test.ts
+++ b/apps/api/src/competition/inbound/http/create-competition-request.mapper.test.ts
@@ -1,0 +1,38 @@
+import { UnauthorizedException } from "@nestjs/common";
+import { describe, expect, it } from "vitest";
+
+import { mapCreateCompetitionRequestToCommand } from "./create-competition-request.mapper.js";
+
+describe("mapCreateCompetitionRequestToCommand", () => {
+  it("maps the authenticated user identity into the application command", () => {
+    expect(
+      mapCreateCompetitionRequestToCommand(
+        {
+          title: "Protected Open",
+          format: "league",
+          startsAt: "2026-05-10T10:00:00.000Z",
+          endsAt: "2026-05-12T18:00:00.000Z",
+        },
+        { id: "user-123" },
+      ),
+    ).toMatchObject({
+      title: "Protected Open",
+      format: "league",
+      ownerId: "user-123",
+    });
+  });
+
+  it("rejects mapping when the authenticated user identity is missing", () => {
+    expect(() =>
+      mapCreateCompetitionRequestToCommand(
+        {
+          title: "Protected Open",
+          format: "league",
+          startsAt: "2026-05-10T10:00:00.000Z",
+          endsAt: "2026-05-12T18:00:00.000Z",
+        },
+        undefined,
+      ),
+    ).toThrow(UnauthorizedException);
+  });
+});

--- a/apps/api/src/competition/inbound/http/create-competition-request.mapper.ts
+++ b/apps/api/src/competition/inbound/http/create-competition-request.mapper.ts
@@ -1,0 +1,24 @@
+import { UnauthorizedException } from "@nestjs/common";
+import { createCompetitionRequestSchema } from "@padel/schemas";
+import { z } from "zod";
+
+import type { AuthenticatedUser } from "../../../common/modules/auth/application/ports/auth-gateway.port.js";
+import type { CreateCompetitionCommand } from "../../application/create-competition.command.js";
+
+type CreateCompetitionRequest = z.infer<typeof createCompetitionRequestSchema>;
+
+export function mapCreateCompetitionRequestToCommand(
+  request: CreateCompetitionRequest,
+  user: Pick<AuthenticatedUser, "id"> | undefined,
+): CreateCompetitionCommand {
+  const ownerId = user?.id;
+
+  if (typeof ownerId !== "string" || ownerId.trim().length === 0) {
+    throw new UnauthorizedException();
+  }
+
+  return {
+    ...request,
+    ownerId,
+  };
+}

--- a/apps/api/src/competition/inbound/http/create-competition-request.mapper.ts
+++ b/apps/api/src/competition/inbound/http/create-competition-request.mapper.ts
@@ -1,6 +1,6 @@
 import { UnauthorizedException } from "@nestjs/common";
-import { createCompetitionRequestSchema } from "@padel/schemas";
-import { z } from "zod";
+import type { createCompetitionRequestSchema } from "@padel/schemas";
+import type { z } from "zod";
 
 import type { AuthenticatedUser } from "../../../common/modules/auth/application/ports/auth-gateway.port.js";
 import type { CreateCompetitionCommand } from "../../application/create-competition.command.js";

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -11,8 +11,8 @@ export const createCompetitionRequestSchema = z
     format: z.enum(["elimination", "round-robin", "league"]),
     startsAt: z.iso.datetime(),
     endsAt: z.iso.datetime(),
-    ownerId: z.string().trim().min(1),
   })
+  .strict()
   .refine(
     ({ startsAt, endsAt }) =>
       new Date(startsAt).getTime() <= new Date(endsAt).getTime(),
@@ -32,7 +32,7 @@ export const createCompetitionResponseSchema = z.object({
   status: z.literal("draft"),
 });
 
-export type CreateCompetitionInput = z.infer<
+export type CreateCompetitionRequest = z.infer<
   typeof createCompetitionRequestSchema
 >;
 export type CreateCompetitionResponse = z.infer<

--- a/packages/schemas/test/index.test.ts
+++ b/packages/schemas/test/index.test.ts
@@ -13,13 +13,23 @@ describe("competition schemas", () => {
         format: "elimination",
         startsAt: "2026-05-10T10:00:00.000Z",
         endsAt: "2026-05-12T18:00:00.000Z",
-        ownerId: "owner-1",
       }),
     ).toMatchObject({
       title: "Regional Open",
       format: "elimination",
-      ownerId: "owner-1",
     });
+  });
+
+  it("rejects a create-competition request that includes ownerId", () => {
+    expect(() =>
+      createCompetitionRequestSchema.parse({
+        title: "Regional Open",
+        format: "elimination",
+        startsAt: "2026-05-10T10:00:00.000Z",
+        endsAt: "2026-05-12T18:00:00.000Z",
+        ownerId: "owner-1",
+      }),
+    ).toThrow();
   });
 
   it("rejects a response with a non-draft status", () => {


### PR DESCRIPTION
## Summary
- require an authenticated session on `POST /competitions`
- derive `ownerId` from the authenticated user at the HTTP boundary instead of trusting the request body
- add mapper, contract, controller, and integration coverage for authenticated and unauthenticated flows

## Changes
- protect the competition create controller with `AuthenticatedGuard` and `@CurrentUser()` mapping
- introduce a backend-owned `CreateCompetitionCommand` plus request-to-command mapper
- remove `ownerId` from the shared create-competition request schema and reject extra request fields
- add unit and integration tests for the request mapping, `401` rejection path, and authenticated create path

## Testing
- `pnpm --filter @padel/schemas test`
- `pnpm --filter @padel/schemas typecheck`
- `pnpm --filter @padel/schemas build`
- `pnpm --filter @padel/api typecheck`
- `pnpm --filter @padel/api test`
- `DATABASE_URL='postgresql://padel:padel@localhost:5433/padel?schema=public' pnpm --filter @padel/api test -- src/competition/inbound/http/competition.controller.integration.test.ts`

Closes #19
