### PR TITLE
feat(ui): add operational feedback primitives

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
+    "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.2.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -13,12 +13,12 @@ const DialogContent = React.forwardRef<
   <DialogPrimitive.Portal>
     <DialogPrimitive.Overlay
       className={cn(
-        "fixed inset-0 z-50 bg-foreground/30 backdrop-blur-[2px] transition-opacity duration-200 data-[state=closed]:opacity-0 data-[state=open]:opacity-100",
+        "fixed inset-0 z-50 bg-foreground/45 backdrop-blur-[3px] transition-opacity duration-200 data-[state=closed]:opacity-0 data-[state=open]:opacity-100",
       )}
     />
     <DialogPrimitive.Content
       className={cn(
-        "fixed left-1/2 top-1/2 z-50 grid w-[min(32rem,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-[calc(var(--radius)+0.2rem)] border bg-card p-6 text-card-foreground shadow-xl outline-hidden transition-[opacity,transform] duration-200 data-[state=closed]:scale-95 data-[state=closed]:opacity-0 data-[state=open]:scale-100 data-[state=open]:opacity-100",
+        "fixed left-1/2 top-1/2 z-50 grid w-[min(32rem,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-[calc(var(--radius)+0.2rem)] border border-border/90 bg-background p-6 text-foreground shadow-[0_24px_60px_hsl(var(--foreground)/0.18)] outline-hidden ring-1 ring-background/70 transition-[opacity,transform] duration-200 data-[state=closed]:scale-95 data-[state=closed]:opacity-0 data-[state=open]:scale-100 data-[state=open]:opacity-100",
         className,
       )}
       data-slot="dialog-content"

--- a/packages/ui/src/components/empty-state.test.tsx
+++ b/packages/ui/src/components/empty-state.test.tsx
@@ -1,0 +1,44 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateDescription,
+  EmptyStateEyebrow,
+  EmptyStateTitle,
+  emptyStateVariants,
+} from "./empty-state.js";
+
+describe("EmptyState", () => {
+  it("renders shared empty-state guidance without workflow orchestration", () => {
+    const markup = renderToStaticMarkup(
+      <EmptyState variant="warning">
+        <EmptyStateEyebrow>No approved registrations</EmptyStateEyebrow>
+        <EmptyStateTitle>
+          Competition structure cannot be generated yet
+        </EmptyStateTitle>
+        <EmptyStateDescription>
+          Approve at least one participant before scheduling categories.
+        </EmptyStateDescription>
+        <EmptyStateActions>
+          <button type="button">Review pending queue</button>
+        </EmptyStateActions>
+      </EmptyState>,
+    );
+
+    expect(markup).toContain('data-slot="empty-state"');
+    expect(markup).toContain('data-slot="empty-state-actions"');
+    expect(markup).toContain("Competition structure cannot be generated yet");
+  });
+
+  it("supports the approved operational variants", () => {
+    expect(emptyStateVariants({ variant: "info" })).toContain("bg-primary/6");
+    expect(emptyStateVariants({ variant: "success" })).toContain(
+      "bg-secondary",
+    );
+    expect(emptyStateVariants({ variant: "warning" })).toContain("bg-accent");
+    expect(emptyStateVariants({ variant: "blocked" })).toContain(
+      "bg-destructive/8",
+    );
+  });
+});

--- a/packages/ui/src/components/empty-state.tsx
+++ b/packages/ui/src/components/empty-state.tsx
@@ -1,0 +1,121 @@
+import { type VariantProps, cva } from "class-variance-authority";
+import * as React from "react";
+import { cn } from "../lib/utils.js";
+
+export const emptyStateVariants = cva(
+  "grid gap-4 rounded-[1.4rem] border border-dashed px-6 py-7 text-center shadow-sm",
+  {
+    variants: {
+      variant: {
+        info: "border-primary/25 bg-primary/6 text-foreground",
+        success: "border-primary/25 bg-secondary text-foreground",
+        warning: "border-accent-foreground/20 bg-accent text-accent-foreground",
+        blocked:
+          "border-destructive/25 bg-destructive/8 text-foreground shadow-[0_0_0_1px_hsl(var(--destructive)/0.08)]",
+      },
+      size: {
+        default: "max-w-xl",
+        compact: "max-w-md px-5 py-6",
+      },
+    },
+    defaultVariants: {
+      variant: "info",
+      size: "default",
+    },
+  },
+);
+
+export interface EmptyStateProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof emptyStateVariants> {}
+
+export const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
+  ({ className, size, variant, ...props }, ref) => (
+    <div
+      className={cn(emptyStateVariants({ className, size, variant }))}
+      data-slot="empty-state"
+      data-variant={variant ?? "info"}
+      ref={ref}
+      {...props}
+    />
+  ),
+);
+
+EmptyState.displayName = "EmptyState";
+
+export interface EmptyStateEyebrowProps
+  extends React.HTMLAttributes<HTMLParagraphElement> {}
+
+export const EmptyStateEyebrow = React.forwardRef<
+  HTMLParagraphElement,
+  EmptyStateEyebrowProps
+>(({ className, ...props }, ref) => (
+  <p
+    className={cn(
+      "mx-auto w-fit rounded-full bg-background/70 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground",
+      className,
+    )}
+    data-slot="empty-state-eyebrow"
+    ref={ref}
+    {...props}
+  />
+));
+
+EmptyStateEyebrow.displayName = "EmptyStateEyebrow";
+
+export interface EmptyStateTitleProps
+  extends React.HTMLAttributes<HTMLHeadingElement> {}
+
+export const EmptyStateTitle = React.forwardRef<
+  HTMLHeadingElement,
+  EmptyStateTitleProps
+>(({ className, ...props }, ref) => (
+  <h3
+    className={cn("text-xl font-semibold tracking-tight", className)}
+    data-slot="empty-state-title"
+    ref={ref}
+    {...props}
+  />
+));
+
+EmptyStateTitle.displayName = "EmptyStateTitle";
+
+export interface EmptyStateDescriptionProps
+  extends React.HTMLAttributes<HTMLParagraphElement> {}
+
+export const EmptyStateDescription = React.forwardRef<
+  HTMLParagraphElement,
+  EmptyStateDescriptionProps
+>(({ className, ...props }, ref) => (
+  <p
+    className={cn(
+      "mx-auto max-w-prose text-sm leading-6 text-muted-foreground data-[variant=warning]:text-accent-foreground/80 data-[variant=blocked]:text-foreground/80",
+      className,
+    )}
+    data-slot="empty-state-description"
+    ref={ref}
+    {...props}
+  />
+));
+
+EmptyStateDescription.displayName = "EmptyStateDescription";
+
+export interface EmptyStateActionsProps
+  extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const EmptyStateActions = React.forwardRef<
+  HTMLDivElement,
+  EmptyStateActionsProps
+>(({ className, ...props }, ref) => (
+  <div
+    className={cn(
+      "flex flex-wrap items-center justify-center gap-3 pt-1",
+      className,
+    )}
+    data-slot="empty-state-actions"
+    ref={ref}
+    {...props}
+  />
+));
+
+EmptyStateActions.displayName = "EmptyStateActions";

--- a/packages/ui/src/components/inline-alert.test.tsx
+++ b/packages/ui/src/components/inline-alert.test.tsx
@@ -1,0 +1,43 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  InlineAlert,
+  InlineAlertActions,
+  InlineAlertDescription,
+  InlineAlertTitle,
+  inlineAlertVariants,
+} from "./inline-alert.js";
+
+describe("InlineAlert", () => {
+  it("renders a persistent shared feedback surface with status semantics", () => {
+    const markup = renderToStaticMarkup(
+      <InlineAlert variant="blocked">
+        <InlineAlertTitle variant="blocked">
+          Bracket publishing blocked
+        </InlineAlertTitle>
+        <InlineAlertDescription>
+          Resolve incomplete quarterfinal results before continuing.
+        </InlineAlertDescription>
+        <InlineAlertActions>
+          <button type="button">Review matches</button>
+        </InlineAlertActions>
+      </InlineAlert>,
+    );
+
+    expect(markup).toContain('data-slot="inline-alert"');
+    expect(markup).toContain('role="alert"');
+    expect(markup).toContain('data-slot="inline-alert-actions"');
+    expect(markup).toContain("Bracket publishing blocked");
+  });
+
+  it("supports the approved operational variants", () => {
+    expect(inlineAlertVariants({ variant: "info" })).toContain("bg-primary/8");
+    expect(inlineAlertVariants({ variant: "success" })).toContain(
+      "bg-secondary",
+    );
+    expect(inlineAlertVariants({ variant: "warning" })).toContain("bg-accent");
+    expect(inlineAlertVariants({ variant: "blocked" })).toContain(
+      "bg-destructive/10",
+    );
+  });
+});

--- a/packages/ui/src/components/inline-alert.tsx
+++ b/packages/ui/src/components/inline-alert.tsx
@@ -76,7 +76,7 @@ export const InlineAlertTitle = React.forwardRef<
   return (
     <h3
       className={cn(
-        "flex items-center gap-2 text-sm font-semibold tracking-tight",
+        "grid items-start gap-x-3 gap-y-1 text-sm font-semibold tracking-tight sm:col-span-2 sm:grid-cols-[auto_1fr]",
         className,
       )}
       data-slot="inline-alert-title"
@@ -86,7 +86,7 @@ export const InlineAlertTitle = React.forwardRef<
       <span
         aria-hidden="true"
         className={cn(
-          "inline-flex min-w-16 rounded-full px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em]",
+          "inline-flex min-w-0 items-center self-start rounded-full px-2.5 py-1 text-[0.68rem] leading-none font-semibold uppercase tracking-[0.12em]",
           resolvedVariant === "info" && "bg-primary/14 text-primary",
           resolvedVariant === "success" && "bg-primary text-primary-foreground",
           resolvedVariant === "warning" &&
@@ -97,7 +97,7 @@ export const InlineAlertTitle = React.forwardRef<
       >
         {inlineAlertStatusText[resolvedVariant]}
       </span>
-      <span>{children}</span>
+      <span className="leading-5">{children}</span>
     </h3>
   );
 });
@@ -113,7 +113,7 @@ export const InlineAlertDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     className={cn(
-      "text-sm leading-6 text-muted-foreground data-[variant=warning]:text-accent-foreground/80 data-[variant=blocked]:text-foreground/80",
+      "text-sm leading-6 text-muted-foreground sm:col-start-2 sm:-mt-1 data-[variant=warning]:text-accent-foreground/80 data-[variant=blocked]:text-foreground/80",
       className,
     )}
     data-slot="inline-alert-description"

--- a/packages/ui/src/components/inline-alert.tsx
+++ b/packages/ui/src/components/inline-alert.tsx
@@ -1,0 +1,145 @@
+import { type VariantProps, cva } from "class-variance-authority";
+import * as React from "react";
+import { cn } from "../lib/utils.js";
+
+export const inlineAlertVariants = cva(
+  "grid gap-3 rounded-xl border px-4 py-4 shadow-sm",
+  {
+    variants: {
+      variant: {
+        info: "border-primary/25 bg-primary/8 text-foreground",
+        success: "border-primary/35 bg-secondary text-foreground",
+        warning: "border-accent-foreground/20 bg-accent text-accent-foreground",
+        blocked:
+          "border-destructive/25 bg-destructive/10 text-foreground shadow-[0_0_0_1px_hsl(var(--destructive)/0.08)]",
+      },
+      density: {
+        default: "sm:grid-cols-[auto_1fr]",
+        compact: "gap-2 px-3 py-3",
+      },
+    },
+    defaultVariants: {
+      variant: "info",
+      density: "default",
+    },
+  },
+);
+
+const inlineAlertStatusText = {
+  blocked: "Blocked",
+  info: "Info",
+  success: "Success",
+  warning: "Warning",
+} as const;
+
+export interface InlineAlertProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof inlineAlertVariants> {
+  role?: "alert" | "status";
+}
+
+export const InlineAlert = React.forwardRef<HTMLDivElement, InlineAlertProps>(
+  ({ className, density, role, variant, ...props }, ref) => {
+    const resolvedVariant = variant ?? "info";
+    const resolvedRole =
+      role ??
+      (resolvedVariant === "warning" || resolvedVariant === "blocked"
+        ? "alert"
+        : "status");
+
+    return (
+      <div
+        className={cn(inlineAlertVariants({ className, density, variant }))}
+        data-slot="inline-alert"
+        data-variant={resolvedVariant}
+        ref={ref}
+        role={resolvedRole}
+        {...props}
+      />
+    );
+  },
+);
+
+InlineAlert.displayName = "InlineAlert";
+
+export interface InlineAlertTitleProps
+  extends React.HTMLAttributes<HTMLHeadingElement> {
+  variant?: VariantProps<typeof inlineAlertVariants>["variant"];
+}
+
+export const InlineAlertTitle = React.forwardRef<
+  HTMLHeadingElement,
+  InlineAlertTitleProps
+>(({ children, className, variant = "info", ...props }, ref) => {
+  const resolvedVariant = variant ?? "info";
+
+  return (
+    <h3
+      className={cn(
+        "flex items-center gap-2 text-sm font-semibold tracking-tight",
+        className,
+      )}
+      data-slot="inline-alert-title"
+      ref={ref}
+      {...props}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "inline-flex min-w-16 rounded-full px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em]",
+          resolvedVariant === "info" && "bg-primary/14 text-primary",
+          resolvedVariant === "success" && "bg-primary text-primary-foreground",
+          resolvedVariant === "warning" &&
+            "bg-accent-foreground/10 text-accent-foreground",
+          resolvedVariant === "blocked" &&
+            "bg-destructive text-destructive-foreground",
+        )}
+      >
+        {inlineAlertStatusText[resolvedVariant]}
+      </span>
+      <span>{children}</span>
+    </h3>
+  );
+});
+
+InlineAlertTitle.displayName = "InlineAlertTitle";
+
+export interface InlineAlertDescriptionProps
+  extends React.HTMLAttributes<HTMLParagraphElement> {}
+
+export const InlineAlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  InlineAlertDescriptionProps
+>(({ className, ...props }, ref) => (
+  <p
+    className={cn(
+      "text-sm leading-6 text-muted-foreground data-[variant=warning]:text-accent-foreground/80 data-[variant=blocked]:text-foreground/80",
+      className,
+    )}
+    data-slot="inline-alert-description"
+    ref={ref}
+    {...props}
+  />
+));
+
+InlineAlertDescription.displayName = "InlineAlertDescription";
+
+export interface InlineAlertActionsProps
+  extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const InlineAlertActions = React.forwardRef<
+  HTMLDivElement,
+  InlineAlertActionsProps
+>(({ className, ...props }, ref) => (
+  <div
+    className={cn(
+      "flex flex-wrap items-center gap-2 pt-1 sm:col-start-2",
+      className,
+    )}
+    data-slot="inline-alert-actions"
+    ref={ref}
+    {...props}
+  />
+));
+
+InlineAlertActions.displayName = "InlineAlertActions";

--- a/packages/ui/src/components/toast.test.tsx
+++ b/packages/ui/src/components/toast.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  Toast,
+  ToastAction,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+  toastVariants,
+} from "./toast.js";
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => undefined;
+  }
+
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => undefined;
+  }
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Toast", () => {
+  it("renders transient package-local feedback without router or mutation coupling", async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <ToastProvider>
+        <Toast
+          defaultOpen
+          duration={60_000}
+          onOpenChange={onOpenChange}
+          variant="success"
+        >
+          <ToastTitle>Results saved</ToastTitle>
+          <ToastDescription>
+            Semifinal progression was recalculated successfully.
+          </ToastDescription>
+          <ToastAction altText="Review standings">Review standings</ToastAction>
+          <ToastClose />
+        </Toast>
+        <ToastViewport />
+      </ToastProvider>,
+    );
+
+    const title = await screen.findByText(/results saved/i);
+    const toastItem = title.closest('[data-slot="toast"]');
+
+    expect(toastItem).not.toBeNull();
+    expect(document.body.contains(toastItem)).toBe(true);
+
+    expect(
+      screen.getByRole("button", { name: /review standings/i }),
+    ).not.toBeNull();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /dismiss notification/i }),
+    );
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("supports the approved operational variants", () => {
+    expect(toastVariants({ variant: "info" })).toContain("bg-background/95");
+    expect(toastVariants({ variant: "success" })).toContain("bg-secondary");
+    expect(toastVariants({ variant: "warning" })).toContain("bg-accent");
+    expect(toastVariants({ variant: "blocked" })).toContain(
+      "bg-destructive/10",
+    );
+  });
+});

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -1,0 +1,146 @@
+import * as ToastPrimitives from "@radix-ui/react-toast";
+import { type VariantProps, cva } from "class-variance-authority";
+import * as React from "react";
+import { cn } from "../lib/utils.js";
+
+export const ToastProvider = ToastPrimitives.Provider;
+
+export type ToastViewportProps = React.ComponentPropsWithoutRef<
+  typeof ToastPrimitives.Viewport
+>;
+
+export const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  ToastViewportProps
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    className={cn(
+      "fixed top-0 z-50 flex max-h-screen w-full flex-col-reverse gap-3 p-4 outline-hidden sm:right-0 sm:top-auto sm:bottom-0 sm:max-w-[28rem]",
+      className,
+    )}
+    data-slot="toast-viewport"
+    ref={ref}
+    {...props}
+  />
+));
+
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+
+export const toastVariants = cva(
+  "group pointer-events-auto relative grid gap-2 overflow-hidden rounded-2xl border px-4 py-4 shadow-lg backdrop-blur-sm transition-[opacity,transform] data-[state=closed]:translate-y-2 data-[state=closed]:opacity-0 data-[state=open]:translate-y-0 data-[state=open]:opacity-100 data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none",
+  {
+    variants: {
+      variant: {
+        info: "border-primary/25 bg-background/95 text-foreground",
+        success: "border-primary/30 bg-secondary text-foreground",
+        warning: "border-accent-foreground/20 bg-accent text-accent-foreground",
+        blocked:
+          "border-destructive/25 bg-destructive/10 text-foreground shadow-[0_0_0_1px_hsl(var(--destructive)/0.08)]",
+      },
+    },
+    defaultVariants: {
+      variant: "info",
+    },
+  },
+);
+
+export interface ToastProps
+  extends React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root>,
+    VariantProps<typeof toastVariants> {}
+
+export const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  ToastProps
+>(({ className, variant, ...props }, ref) => (
+  <ToastPrimitives.Root
+    className={cn(toastVariants({ className, variant }))}
+    data-slot="toast"
+    data-variant={variant ?? "info"}
+    ref={ref}
+    {...props}
+  />
+));
+
+Toast.displayName = ToastPrimitives.Root.displayName;
+
+export interface ToastTitleProps
+  extends React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title> {}
+
+export const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  ToastTitleProps
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    className={cn("text-sm font-semibold tracking-tight", className)}
+    data-slot="toast-title"
+    ref={ref}
+    {...props}
+  />
+));
+
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
+
+export interface ToastDescriptionProps
+  extends React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description> {}
+
+export const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  ToastDescriptionProps
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    className={cn(
+      "text-sm leading-6 text-muted-foreground data-[variant=warning]:text-accent-foreground/80 data-[variant=blocked]:text-foreground/80",
+      className,
+    )}
+    data-slot="toast-description"
+    ref={ref}
+    {...props}
+  />
+));
+
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
+
+export type ToastActionProps = React.ComponentPropsWithoutRef<
+  typeof ToastPrimitives.Action
+>;
+
+export const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  ToastActionProps
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    className={cn(
+      "inline-flex h-9 shrink-0 items-center justify-center rounded-md border border-border bg-background px-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden group-data-[variant=blocked]:border-destructive/25 group-data-[variant=blocked]:bg-destructive/6 group-data-[variant=warning]:border-accent-foreground/15 group-data-[variant=warning]:bg-background/60",
+      className,
+    )}
+    data-slot="toast-action"
+    ref={ref}
+    {...props}
+  />
+));
+
+ToastAction.displayName = ToastPrimitives.Action.displayName;
+
+export type ToastCloseProps = React.ComponentPropsWithoutRef<
+  typeof ToastPrimitives.Close
+>;
+
+export const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  ToastCloseProps
+>(({ children, className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    className={cn(
+      "absolute top-3 right-3 inline-flex h-8 w-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-hidden",
+      className,
+    )}
+    data-slot="toast-close"
+    ref={ref}
+    {...props}
+  >
+    {children ?? <span aria-hidden="true">x</span>}
+    <span className="sr-only">Dismiss notification</span>
+  </ToastPrimitives.Close>
+));
+
+ToastClose.displayName = ToastPrimitives.Close.displayName;

--- a/packages/ui/src/empty-state.stories.tsx
+++ b/packages/ui/src/empty-state.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "./components/button.js";
+import {
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateDescription,
+  EmptyStateEyebrow,
+  EmptyStateTitle,
+} from "./components/empty-state.js";
+
+const meta = {
+  title: "Shared/Feedback/Empty State",
+  component: EmptyState,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Empty-state surface for workflow gaps, not generic decoration. Use it when a section has no records, when a process has not started yet, or when a blocked prerequisite leaves the user with nothing useful to scan. Keep routing and data-fetch ownership outside the shared component and compose local actions into the provided action slot.",
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["info", "success", "warning", "blocked"],
+    },
+    size: {
+      control: "select",
+      options: ["default", "compact"],
+    },
+  },
+  render: (args) => (
+    <EmptyState {...args}>
+      <EmptyStateEyebrow>Category scheduling</EmptyStateEyebrow>
+      <EmptyStateTitle>No approved pairs available yet</EmptyStateTitle>
+      <EmptyStateDescription data-variant={args.variant}>
+        Empty states should explain why the section is empty and what the
+        operator can do next, especially in dense administrative workflows.
+      </EmptyStateDescription>
+      <EmptyStateActions>
+        <Button variant="outline">Review registrations</Button>
+        <Button variant="ghost">Open import guide</Button>
+      </EmptyStateActions>
+    </EmptyState>
+  ),
+} satisfies Meta<typeof EmptyState>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    variant: "info",
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    variant: "warning",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Warning empty states are useful when a list is empty because a review or setup step remains incomplete, but the workflow is not fully blocked.",
+      },
+    },
+  },
+};
+
+export const Blocked: Story = {
+  args: {
+    variant: "blocked",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Blocked empty states should make the missing prerequisite explicit rather than leaving the user with a blank surface and no explanation.",
+      },
+    },
+  },
+};
+
+export const Compact: Story = {
+  args: {
+    size: "compact",
+    variant: "success",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Compact mode works inside cards, side panels, and dense operational modules where the default layout would be too spacious.",
+      },
+    },
+  },
+};

--- a/packages/ui/src/index.test.tsx
+++ b/packages/ui/src/index.test.tsx
@@ -1,14 +1,24 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { Input, Label, Textarea } from "./index.js";
+import {
+  EmptyState,
+  InlineAlert,
+  Input,
+  Label,
+  Textarea,
+  ToastProvider,
+} from "./index.js";
 
 describe("ui package entrypoint", () => {
-  it("exports form primitives for shared package consumption", () => {
+  it("exports shared form and feedback primitives for package consumption", () => {
     const markup = renderToStaticMarkup(
       <>
         <Label htmlFor="captain-name">Captain name</Label>
         <Input id="captain-name" placeholder="Alicia Gomez" />
         <Textarea defaultValue="Referee notes" />
+        <InlineAlert>Review pending registrations.</InlineAlert>
+        <EmptyState>No matches scheduled yet.</EmptyState>
+        <ToastProvider />
       </>,
     );
 
@@ -16,5 +26,7 @@ describe("ui package entrypoint", () => {
     expect(markup).toContain('data-slot="label"');
     expect(markup).toContain('data-slot="input"');
     expect(markup).toContain('data-slot="textarea"');
+    expect(markup).toContain('data-slot="inline-alert"');
+    expect(markup).toContain('data-slot="empty-state"');
   });
 });

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -27,6 +27,34 @@ export {
   DialogTrigger,
 } from "./components/dialog.js";
 export {
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateDescription,
+  EmptyStateEyebrow,
+  EmptyStateTitle,
+  emptyStateVariants,
+} from "./components/empty-state.js";
+export type {
+  EmptyStateActionsProps,
+  EmptyStateDescriptionProps,
+  EmptyStateEyebrowProps,
+  EmptyStateProps,
+  EmptyStateTitleProps,
+} from "./components/empty-state.js";
+export {
+  InlineAlert,
+  InlineAlertActions,
+  InlineAlertDescription,
+  InlineAlertTitle,
+  inlineAlertVariants,
+} from "./components/inline-alert.js";
+export type {
+  InlineAlertActionsProps,
+  InlineAlertDescriptionProps,
+  InlineAlertProps,
+  InlineAlertTitleProps,
+} from "./components/inline-alert.js";
+export {
   Popover,
   PopoverAnchor,
   PopoverContent,
@@ -79,6 +107,24 @@ export {
 export type { SwitchProps } from "./components/switch.js";
 export { Textarea } from "./components/textarea.js";
 export type { TextareaProps } from "./components/textarea.js";
+export {
+  Toast,
+  ToastAction,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+  toastVariants,
+} from "./components/toast.js";
+export type {
+  ToastActionProps,
+  ToastCloseProps,
+  ToastDescriptionProps,
+  ToastProps,
+  ToastTitleProps,
+  ToastViewportProps,
+} from "./components/toast.js";
 export {
   Tooltip,
   TooltipContent,

--- a/packages/ui/src/inline-alert.stories.tsx
+++ b/packages/ui/src/inline-alert.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, within } from "@storybook/test";
+import { Button } from "./components/button.js";
+import {
+  InlineAlert,
+  InlineAlertActions,
+  InlineAlertDescription,
+  InlineAlertTitle,
+} from "./components/inline-alert.js";
+
+const meta = {
+  title: "Shared/Feedback/Inline Alert",
+  component: InlineAlert,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Persistent operational feedback for conditions that must remain visible near the affected workflow. Use `Inline Alert` for blocked, warning, success, or informational states that require context, explanation, or follow-up action. Prefer a toast only when the message is transient and the user can safely continue without keeping the message pinned on screen.",
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["info", "success", "warning", "blocked"],
+    },
+    density: {
+      control: "select",
+      options: ["default", "compact"],
+    },
+  },
+  render: (args) => (
+    <InlineAlert {...args}>
+      <InlineAlertTitle variant={args.variant}>
+        Registration review needs attention
+      </InlineAlertTitle>
+      <InlineAlertDescription data-variant={args.variant}>
+        A participant is missing category evidence. Keep the message in flow
+        until the reviewer resolves or overrides the issue.
+      </InlineAlertDescription>
+      <InlineAlertActions>
+        <Button size="sm" variant="outline">
+          Review evidence
+        </Button>
+        <Button size="sm" variant="ghost">
+          Mark for follow-up
+        </Button>
+      </InlineAlertActions>
+    </InlineAlert>
+  ),
+} satisfies Meta<typeof InlineAlert>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Informational: Story = {
+  args: {
+    variant: "info",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Informational guidance keeps workflow context visible without interrupting the user or escalating urgency.",
+      },
+    },
+  },
+};
+
+export const Blocked: Story = {
+  args: {
+    variant: "blocked",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Blocked state uses assertive semantics and stronger visual weight because the workflow cannot safely continue.",
+      },
+    },
+  },
+};
+
+export const VariantMatrix: Story = {
+  render: () => (
+    <div className="grid max-w-3xl gap-4">
+      {(["info", "success", "warning", "blocked"] as const).map((variant) => (
+        <InlineAlert key={variant} variant={variant}>
+          <InlineAlertTitle variant={variant}>
+            {variant === "info" && "Competition saved as draft"}
+            {variant === "success" && "Registrant approved"}
+            {variant === "warning" && "Division assignment still needs review"}
+            {variant === "blocked" && "Bracket publication is blocked"}
+          </InlineAlertTitle>
+          <InlineAlertDescription data-variant={variant}>
+            Storybook keeps severity semantics visible so app teams do not
+            invent local alert markup for operational states.
+          </InlineAlertDescription>
+        </InlineAlert>
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Reference matrix for the approved operational states: informational, success, warning, and blocked.",
+      },
+    },
+  },
+};
+
+export const AccessibilitySemantics: Story = {
+  args: {
+    variant: "blocked",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("alert")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("heading", {
+        name: /registration review needs attention/i,
+      }),
+    ).toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Blocked and warning alerts should use assertive semantics when the workflow is at risk; informational and success states can remain polite status messaging.",
+      },
+    },
+  },
+};

--- a/packages/ui/src/toast.stories.tsx
+++ b/packages/ui/src/toast.stories.tsx
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, userEvent, within } from "@storybook/test";
+import * as React from "react";
+import {
+  Toast,
+  ToastAction,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "./components/toast.js";
+
+function ToastStoryDemo({
+  variant = "info",
+}: {
+  variant?: "blocked" | "info" | "success" | "warning";
+}) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <ToastProvider>
+      <button
+        className="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 text-sm font-medium shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground"
+        onClick={() => setOpen(true)}
+        type="button"
+      >
+        Trigger toast
+      </button>
+      <Toast onOpenChange={setOpen} open={open} variant={variant}>
+        <ToastTitle>
+          {variant === "success" && "Result saved"}
+          {variant === "info" && "Draft auto-saved"}
+          {variant === "warning" && "Review queue still has pending pairs"}
+          {variant === "blocked" && "Closure request cannot proceed"}
+        </ToastTitle>
+        <ToastDescription data-variant={variant}>
+          Use transient feedback only when the user can continue without keeping
+          the message pinned inside the workflow surface.
+        </ToastDescription>
+        <div className="mt-1 flex flex-wrap items-center gap-2">
+          <ToastAction altText="Open details">Open details</ToastAction>
+          <ToastClose />
+        </div>
+      </Toast>
+      <ToastViewport />
+    </ToastProvider>
+  );
+}
+
+const meta = {
+  title: "Shared/Feedback/Toast",
+  component: Toast,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Transient operational feedback for lightweight confirmation or non-blocking attention cues. Use a toast when the message should be announced, then leave the screen clear. Do not use it as the only place for blocking failures, field corrections, or workflow rationale that must remain visible near the affected content.",
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["info", "success", "warning", "blocked"],
+    },
+  },
+  render: (args) => <ToastStoryDemo variant={args.variant ?? "info"} />,
+} satisfies Meta<typeof Toast>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Informational: Story = {
+  args: {
+    variant: "info",
+  },
+};
+
+export const Success: Story = {
+  args: {
+    variant: "success",
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    variant: "warning",
+  },
+};
+
+export const TriggerAndDismiss: Story = {
+  args: {
+    variant: "success",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: /trigger toast/i }),
+    );
+
+    await expect(body.getByText(/result saved/i)).toBeInTheDocument();
+
+    await userEvent.click(
+      body.getByRole("button", { name: /dismiss notification/i }),
+    );
+
+    await expect(body.queryByText(/result saved/i)).not.toBeInTheDocument();
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Interaction story covering transient announcement, package-owned portal rendering, and explicit dismissal.",
+      },
+    },
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,9 @@ importers:
       '@radix-ui/react-switch':
         specifier: ^1.2.6
         version: 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-toast':
+        specifier: ^1.2.15
+        version: 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1573,6 +1576,19 @@ packages:
 
   '@radix-ui/react-switch@1.2.6':
     resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.15':
+    resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6267,6 +6283,26 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:


### PR DESCRIPTION
## Summary
- add shared `InlineAlert`, `EmptyState`, and Radix-based `Toast` primitives to `packages/ui`
- document operational variants, transient vs persistent guidance, and accessibility expectations in Storybook
- add unit and integration-oriented tests for rendering, variants, exports, and package-local overlay behavior

## Testing
- pnpm --filter @padel/ui lint
- pnpm --filter @padel/ui typecheck
- pnpm --filter @padel/ui test
- pnpm --filter @padel/ui build
- pnpm --filter @padel/ui storybook:build
- pre-push affected checks for lint, typecheck, test, build and module boundaries

Closes #30