### PR TITLE
feat(ui): add numeric and date-oriented inputs

### DIFF
--- a/docs/09-agile/product-backlog.md
+++ b/docs/09-agile/product-backlog.md
@@ -468,3 +468,41 @@ For each ticket, include:
 - GitHub labels: `type:task`, `lane:frontend`, `area:ui-package`, `area:storybook`, `target:packages-ui`, `target:packages-config`
 - milestone/sprint: `next-foundation-sprint`
 - GitHub issue URL or placeholder: `https://github.com/Damimd10/padel/issues/24`
+
+### TKT-029 - Add advanced numeric and date-oriented form inputs to the shared UI package
+
+- ID: `TKT-029`
+- type: `task`
+- epic: `ui-package-foundation`
+- delivery lane: `frontend`
+- affected apps/packages: `packages/ui`, `packages/config`
+- title: `Add shared numeric and date-oriented form inputs in packages/ui`
+- story/task description: Extend `packages/ui` with the next reusable input wave needed by competition creation and result-entry workflows. This ticket should add a shared `Numeric Input`, `Date Input`, and `Date Range Input` surface that stays generic to input semantics, works cleanly with the existing `Field` composition model, and documents the states needed for high-impact admin forms.
+- acceptance criteria:
+  - `packages/ui` exports reusable numeric and date-oriented input surfaces through the shared package entrypoint
+  - the public APIs stay generic and avoid feature-specific parsing, persistence, or workflow orchestration
+  - Storybook documents default, invalid, disabled, read-only and keyboard-relevant states for the shipped inputs
+  - `Date Range Input` documents the shared contract clearly enough that feature code can map it into TanStack Form without app-local reinvention
+  - tests validate the public rendering and interaction behavior of the shipped input surfaces
+- linked docs:
+  - `/docs/03-requirements/functional-requirements.md`
+  - `/docs/04-use-cases/use-cases.md`
+  - `/docs/11-design-system/component-inventory.md`
+  - `/docs/11-design-system/component-states.md`
+  - `/docs/12-frontend-architecture/forms-and-validation.md`
+  - `/docs/13-ui-package-storybook/storybook-guidelines.md`
+  - `/docs/13-ui-package-storybook/numeric-date-inputs.md`
+- linked ADRs:
+  - `/docs/07-adrs/adr-002-frontend-architecture.md`
+  - `/docs/07-adrs/adr-008-monorepo-tooling.md`
+  - `/docs/07-adrs/adr-009-testing-stack.md`
+- testing expectations:
+  - unit: validate input semantics, invalid-state wiring and keyboard-relevant behavior
+  - integration: verify the new controls compose with `Field` and package entrypoints without app-specific dependencies
+  - e2e/manual: confirm Storybook demonstrates the state matrix needed for competition configuration and result-entry forms
+- estimate: `M`
+- status: `approved`
+- implementation workflow: `frontend`
+- GitHub labels: `type:task`, `lane:frontend`, `area:ui-package`, `area:storybook`, `target:packages-ui`, `target:packages-config`
+- milestone/sprint: `next-ui-package-sprint`
+- GitHub issue URL or placeholder: `https://github.com/Damimd10/padel/issues/29`

--- a/docs/09-agile/sprint-backlog.md
+++ b/docs/09-agile/sprint-backlog.md
@@ -26,27 +26,17 @@ If this document and the GitHub Project disagree, update both and record the rea
 - `TKT-014` is delivered as the first backend implementation slice for competition creation under `CORE-01`.
 - `TKT-015` is delivered as the local PostgreSQL infrastructure path for Prisma, NestJS integration, and repository-backed database tests.
 - `TKT-016` is delivered as the Better Auth foundation for application authentication, including PostgreSQL-backed session persistence and documented local validation.
-- The next recommended backend ticket after that is `TKT-017`, protecting competition creation with authenticated organizer identity.
-- The next recommended frontend shared-UI baseline is `TKT-018`, establishing the form foundation needed before the rest of the `packages/ui` component wave.
-- After `TKT-018`, `TKT-019` and `TKT-020` are the preferred parallel tickets because they split cleanly across form-choice controls versus layout and feedback primitives.
-- `TKT-021` should follow once the shared overlay documentation path remains aligned with the approved Storybook and package-boundary rules.
+- `TKT-017` remains the next available backend slice, but it is not part of the current frontend-focused sprint snapshot.
+- `TKT-018`, `TKT-019`, `TKT-020`, and `TKT-021` are treated as delivered shared UI foundation work that enables the next input-focused wave.
+- `TKT-029` is now the active planned frontend sprint item for `next-ui-package-sprint`.
 
 ## Active Sprint Record
 
-- ticket ID and title: `TKT-015` - Provision local PostgreSQL with Docker for Prisma and Nest integration
-- delivery lane: `infrastructure`
-- affected apps/packages: `apps/api`
+- ticket ID and title: `TKT-029` - Add advanced numeric and date-oriented form inputs in `packages/ui`
+- delivery lane: `frontend`
+- affected apps/packages: `packages/ui`, `packages/config`
 - owner: `unassigned`
-- GitHub issue link: `https://github.com/Damimd10/padel/issues/14`
-- current project status: `done`
+- GitHub issue link: `https://github.com/Damimd10/padel/issues/29`
+- current project status: `In Sprint`
 - blocked/unblocked state: `unblocked`
-- notes for carryover risk: `none; Better Auth foundation now depends on the delivered local PostgreSQL workflow instead of a remote/shared database`
-
-- ticket ID and title: `TKT-016` - Establish Better Auth foundation for application authentication
-- delivery lane: `backend`
-- affected apps/packages: `apps/api`, `apps/web`
-- owner: `unassigned`
-- GitHub issue link: `https://github.com/Damimd10/padel/issues/15`
-- current project status: `done`
-- blocked/unblocked state: `unblocked`
-- notes for carryover risk: `none; the auth foundation is delivered and the next follow-up is protected competition behavior rather than more platform auth wiring`
+- notes for carryover risk: `none; GitHub issue metadata, project status, and sprint docs are aligned for implementation`

--- a/docs/09-agile/sprint-plan.md
+++ b/docs/09-agile/sprint-plan.md
@@ -29,39 +29,30 @@ Every committed ticket must:
 
 ## Planning Snapshot
 
-- sprint goal: open a parallel `packages/ui` delivery track while keeping the next backend protection slice available
-- sprint dates or iteration label: `next-foundation-sprint`
+- sprint goal: deliver the next shared form-input wave in `packages/ui` so competition configuration and result-entry workflows can rely on approved numeric and date-oriented controls
+- sprint dates or iteration label: `next-ui-package-sprint`
 - capacity assumptions:
-  - monorepo, UI foundation, Storybook bootstrap, backend persistence, and the first competition-create backend slice are already delivered or accepted on `master`
-  - local PostgreSQL infrastructure and the Better Auth foundation are now delivered, so the next backend bottleneck is protected competition-management behavior
-  - `packages/ui` and Storybook are ready for the next reusable shared-component wave without reopening stack decisions
+  - the shared UI foundation, Storybook bootstrap, form foundations, choice controls, layout primitives, and overlay primitives are already delivered on `master`
+  - the next highest-value UI-package gap for product workflows is the numeric and date-oriented input wave documented under `TKT-029`
+  - implementation should stay focused on shared input semantics and should not expand into feature-specific parsing, persistence, or async date-picker behavior
 - committed tickets:
-  - `TKT-018` - establish the form foundations for reusable data-entry controls in `packages/ui`
+  - `TKT-029` - add advanced numeric and date-oriented form inputs in `packages/ui`
 - stretch tickets:
-  - `TKT-019` - add selection and choice controls in `packages/ui`
-  - `TKT-020` - add layout and feedback primitives in `packages/ui`
-  - `TKT-021` - add interactive overlays in `packages/ui`
-  - `TKT-017` - require authenticated identity at the competition-create inbound boundary
+  - none yet; keep the sprint focused on landing the numeric and date-oriented input contract cleanly before queueing the next shared-control wave
 - lane balance across frontend / backend / infrastructure:
-  - infrastructure: no new sprint-critical infrastructure work is required for this wave
-  - frontend: `TKT-018` opens the next shared UI lane, with `TKT-019` and `TKT-020` eligible to run in parallel after that baseline lands
-  - backend: `TKT-017` remains available as the next backend slice without blocking the UI package track
+  - infrastructure: no sprint-critical infrastructure work is required for this wave
+  - frontend: `TKT-029` is the only committed UI-package item and should own the sprint focus
+  - backend: no backend ticket is committed in this sprint snapshot
 - affected apps/packages summary:
-  - `TKT-017`: `apps/api`, `packages/schemas`
-  - `TKT-018`: `packages/ui`, `packages/config`
-  - `TKT-019`: `packages/ui`, `packages/config`
-  - `TKT-020`: `packages/ui`, `packages/config`
-  - `TKT-021`: `packages/ui`, `packages/config`
+  - `TKT-029`: `packages/ui`, `packages/config`
 - dependencies and blockers:
-  - `TKT-018` should establish the field-level baseline and Storybook documentation contract before more specialized shared input components expand the API surface
-  - `TKT-019` and `TKT-020` can run in parallel once `TKT-018` lands because they touch different component families
-  - `TKT-021` depends on the shared overlay documentation and portal behavior already established by the Storybook foundation and should avoid reopening package-boundary decisions
-  - `TKT-017` should consume the delivered auth foundation instead of reopening auth-tool or session-wiring decisions
+  - `TKT-029` depends on the delivered `Field` contract and previously shipped shared form primitives already present in `packages/ui`
+  - `Date Range Input` must stay generic enough to map into TanStack Form without introducing app-owned business rules into `packages/ui`
 - GitHub milestone / project view used for execution:
-  - milestone: `next-foundation-sprint`
-  - project status: sync after GitHub Issues are created
+  - milestone: `next-ui-package-sprint`
+  - project status: issue `#29` is in `Padel Delivery` with status `In Sprint`
 - exit criteria:
-  - `TKT-018` is implemented with stories and tests and becomes the approved baseline for subsequent form-related controls
-  - `TKT-019` and `TKT-020` can be executed independently without duplicating shared helpers or component taxonomy
-  - `TKT-021` is only started once overlay states and accessibility expectations are explicit in the shared docs and Storybook setup
-  - `TKT-017` remains ready for execution in parallel with the frontend track if backend capacity is available
+  - `TKT-029` lands with shared exports, Storybook coverage, and tests for `Numeric Input`, `Date Input`, and `Date Range Input`
+  - the shipped APIs remain generic and compose with `Field` without feature-specific parsing or submission logic
+  - Storybook documents invalid, disabled, read-only, and keyboard-relevant states clearly enough for competition-configuration and result-entry forms
+  - GitHub execution state stays synced so the sprint doc, issue metadata, and project board all reflect the same committed work

--- a/docs/13-ui-package-storybook/numeric-date-inputs.md
+++ b/docs/13-ui-package-storybook/numeric-date-inputs.md
@@ -1,0 +1,92 @@
+# Numeric and Date-Oriented Inputs
+
+## Context
+
+Issue `TKT-029` / GitHub issue `#29` adds the next reusable input wave for `packages/ui`.
+
+The target controls are:
+
+- `Numeric Input`
+- `Date Input`
+- `Date Range Input`
+
+These controls are needed by competition-configuration and result-entry workflows, but the shared package contract must stay generic to input semantics rather than feature logic.
+
+## Assumptions
+
+- `Field`, `Input`, and the first shared form-control wave already establish the baseline label, description, invalid-state, and entrypoint conventions for `packages/ui`.
+- Shared form controls in `packages/ui` must not own parsing pipelines, persistence rules, form submission behavior, or competition-specific workflow logic.
+- Native browser semantics should be preferred when they preserve a credible shared API and accessibility baseline.
+- Storybook remains the primary validation surface for documenting interaction expectations before app-level forms compose these controls.
+
+## Decisions
+
+### 1. Scope and boundaries
+
+- `Numeric Input` is the shared number-oriented entry surface for quantities, scores, ordering values, and similar bounded numeric data.
+- `Date Input` is the shared single-date entry surface for calendar dates such as registration deadlines, competition start dates, or result dates.
+- `Date Range Input` is the shared two-value date composition surface for start and end dates that belong together semantically.
+- None of these controls should embed competition-specific labels, presets, business-rule validation, timezone workflows, or persistence shaping.
+- `Date Range Input` should focus on shared structure and semantics, not on async calendars, app-owned date math, or feature-specific shortcut behavior.
+
+### 2. Public API direction
+
+- `Numeric Input` should stay close to standard input semantics first, exposing shared support for native attributes such as `min`, `max`, `step`, `inputMode`, `value`, and `defaultValue`.
+- `Date Input` should preserve standard date-field semantics and allow consumers to supply the data shape their form layer owns without forcing package-level parsing helpers.
+- `Date Range Input` should expose an explicit shared contract for two related date values and should compose cleanly with the existing `Field` model rather than replacing it.
+- Shared exports should prefer generic names and prop shapes that make TanStack Form mapping straightforward without leaking workflow meaning into `packages/ui`.
+- If `Date Range Input` needs internal helper subcomponents, those helpers should remain part of a coherent shared API instead of pushing low-level wiring burden into every consuming app.
+
+### 3. Accessibility and interaction contract
+
+- All controls must preserve visible focus treatment, disabled treatment, and invalid-state composition through the shared field contract.
+- `Numeric Input` stories and tests should document keyboard increment and decrement relevance where native behavior is part of the public contract.
+- `Date Input` stories and tests should document read-only, disabled, invalid, and keyboard-relevant states without overpromising browser-specific picker behavior that the package does not control.
+- `Date Range Input` should make start and end relationships explicit in labels, descriptions, or helper structure so consumers do not need to re-invent accessibility wiring for paired dates.
+- Shared package behavior should document what is guaranteed across browsers versus what remains browser-native behavior.
+
+### 4. Storybook documentation contract
+
+Storybook for this wave should organize these controls under `Shared/Forms/...` and cover:
+
+- purpose and when-to-use guidance,
+- default state,
+- disabled state,
+- read-only state where applicable,
+- invalid-state composition with `Field`,
+- keyboard-relevant interaction expectations,
+- dense admin-form examples where the controls appear with labels, descriptions, and validation copy,
+- and explicit boundaries between shared input semantics and app-owned parsing or validation logic.
+
+Recommended minimum stories:
+
+- `Numeric Input`: default, constrained with `min` or `max`, disabled, read-only, invalid with `Field`, keyboard-relevant example
+- `Date Input`: default, with description, disabled, read-only, invalid with `Field`, keyboard-relevant example
+- `Date Range Input`: default pair, invalid start or end example, disabled, read-only if supported, `Field` composition guidance, TanStack Form mapping example in docs
+
+### 5. Testing contract
+
+- Unit coverage should validate prop passthrough, invalid-state wiring, and the public rendering contract for each exported surface.
+- Integration coverage should validate package entrypoint exports and confirm the controls compose with `Field` without app-specific dependencies.
+- Storybook interaction coverage should exercise focus movement and keyboard-relevant behavior where the public contract depends on it.
+- Tests should verify documented shared semantics and accessibility wiring, not browser-specific picker internals that belong outside the package boundary.
+
+## Trade-offs
+
+- Lean shared APIs reduce feature leakage but leave consumers responsible for app-local coercion and business-rule validation.
+- Relying on browser-native date and number behavior keeps the package smaller, but creates some interaction differences across browsers that must be documented honestly.
+- A single `Date Range Input` surface improves reuse, but it requires careful API design so it stays generic rather than turning into a feature-specific mini-form.
+
+## Risks
+
+- If the shared API starts owning parsing or normalization, `packages/ui` could absorb feature logic that belongs in TanStack Form mappings or Zod schemas.
+- If Storybook documents only static rendering, keyboard and invalid-state behavior for dense admin forms may regress unnoticed.
+- If `Date Range Input` is under-specified, each app form may invent different start and end wiring, hurting consistency and accessibility.
+- If browser-native behavior is assumed rather than documented, consumers may expect identical picker UX that the shared package cannot guarantee.
+
+## Next Actions
+
+- Use this document as the acceptance-review checklist for issue `#29` before implementation starts.
+- Keep `Field` as the primary invalid, description, and label composition contract instead of duplicating that structure inside each control.
+- When implementation starts, add Storybook stories and colocated tests in the same pull request as the new exports.
+- If `Date Range Input` needs a more opinionated API than this document supports, pause for a focused ADR or design-system decision instead of improvising in code.

--- a/docs/13-ui-package-storybook/ui-package-overview.md
+++ b/docs/13-ui-package-storybook/ui-package-overview.md
@@ -52,3 +52,4 @@ To keep `packages/ui` parallelizable without breaking package boundaries, the ne
 ## Related docs
 
 - `docs/13-ui-package-storybook/selection-choice-controls.md`
+- `docs/13-ui-package-storybook/numeric-date-inputs.md`

--- a/packages/ui/src/components/date-input.test.tsx
+++ b/packages/ui/src/components/date-input.test.tsx
@@ -1,0 +1,24 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { DateInput } from "./date-input.js";
+
+describe("DateInput", () => {
+  it("renders a shared date field with native date semantics", () => {
+    const markup = renderToStaticMarkup(
+      <DateInput defaultValue="2026-05-03" id="competition-start-date" />,
+    );
+
+    expect(markup).toContain('type="date"');
+    expect(markup).toContain('id="competition-start-date"');
+    expect(markup).toContain('data-slot="input"');
+  });
+
+  it("preserves disabled and read-only public states", () => {
+    const markup = renderToStaticMarkup(
+      <DateInput disabled readOnly value="2026-05-05" />,
+    );
+
+    expect(markup).toContain("disabled");
+    expect(markup).toContain("read-only:bg-muted/40");
+  });
+});

--- a/packages/ui/src/components/date-input.tsx
+++ b/packages/ui/src/components/date-input.tsx
@@ -1,0 +1,10 @@
+import * as React from "react";
+import { Input, type InputProps } from "./input.js";
+
+export interface DateInputProps extends Omit<InputProps, "type"> {}
+
+export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
+  (props, ref) => <Input ref={ref} type="date" {...props} />,
+);
+
+DateInput.displayName = "DateInput";

--- a/packages/ui/src/components/date-range-input.test.tsx
+++ b/packages/ui/src/components/date-range-input.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { DateRangeInput } from "./date-range-input.js";
+import { Field } from "./field.js";
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DateRangeInput", () => {
+  it("renders a grouped shared date-range surface with derived field ids", () => {
+    const markup = renderToStaticMarkup(
+      <DateRangeInput
+        id="registration-window"
+        startProps={{ defaultValue: "2026-05-01", name: "startDate" }}
+        endProps={{ defaultValue: "2026-05-10", name: "endDate" }}
+      />,
+    );
+
+    expect(markup).toContain("<fieldset");
+    expect(markup).toContain('data-slot="date-range-input"');
+    expect(markup).toContain('id="registration-window-start"');
+    expect(markup).toContain('id="registration-window-end"');
+    expect(markup).toContain('name="startDate"');
+    expect(markup).toContain('name="endDate"');
+  });
+
+  it("composes with Field and forwards shared invalid-state semantics to both dates", () => {
+    const markup = renderToStaticMarkup(
+      <Field
+        description="Use local competition dates rather than timestamp values."
+        error="The end date must be on or after the start date."
+        id="registration-window"
+        label="Registration window"
+      >
+        <DateRangeInput />
+      </Field>,
+    );
+
+    expect(markup).toContain(
+      'aria-describedby="registration-window-description registration-window-error"',
+    );
+    expect(markup).toContain('aria-invalid="true"');
+    expect(markup).toContain('id="registration-window-start"');
+    expect(markup).toContain('id="registration-window-end"');
+  });
+
+  it("keeps start and end dates keyboard reachable in sequence", async () => {
+    render(
+      <DateRangeInput
+        aria-label="Competition dates"
+        startProps={{ "aria-label": "Start date" }}
+        endProps={{ "aria-label": "End date" }}
+      />,
+    );
+
+    await userEvent.tab();
+    const start = screen.getByLabelText(/start date/i);
+    expect(start.ownerDocument.activeElement).toBe(start);
+
+    await userEvent.tab();
+    const end = screen.getByLabelText(/end date/i);
+    expect(end.ownerDocument.activeElement).toBe(end);
+  });
+});

--- a/packages/ui/src/components/date-range-input.tsx
+++ b/packages/ui/src/components/date-range-input.tsx
@@ -1,0 +1,106 @@
+import * as React from "react";
+import { cn } from "../lib/utils.js";
+import { DateInput, type DateInputProps } from "./date-input.js";
+import { Label } from "./label.js";
+
+type RangeFieldProps = Omit<DateInputProps, "type">;
+
+function isAriaTrue(
+  value: boolean | "true" | "false" | "grammar" | "spelling" | undefined,
+) {
+  return value === true || value === "true";
+}
+
+export interface DateRangeInputProps
+  extends Omit<
+    React.FieldsetHTMLAttributes<HTMLFieldSetElement>,
+    "children" | "defaultValue" | "onChange"
+  > {
+  disabled?: boolean;
+  endLabel?: React.ReactNode;
+  endProps?: RangeFieldProps;
+  readOnly?: boolean;
+  required?: boolean;
+  separator?: React.ReactNode;
+  startLabel?: React.ReactNode;
+  startProps?: RangeFieldProps;
+}
+
+export const DateRangeInput = React.forwardRef<
+  HTMLFieldSetElement,
+  DateRangeInputProps
+>(
+  (
+    {
+      className,
+      disabled = false,
+      endLabel = "End date",
+      endProps,
+      id,
+      readOnly = false,
+      required = false,
+      separator = "to",
+      startLabel = "Start date",
+      startProps,
+      "aria-describedby": ariaDescribedBy,
+      "aria-invalid": ariaInvalid,
+      "aria-labelledby": ariaLabelledBy,
+      "aria-required": ariaRequired,
+      ...props
+    },
+    ref,
+  ) => {
+    const startId = startProps?.id ?? (id ? `${id}-start` : undefined);
+    const endId = endProps?.id ?? (id ? `${id}-end` : undefined);
+    const invalid = isAriaTrue(ariaInvalid);
+    const isRequired = required || isAriaTrue(ariaRequired);
+
+    return (
+      <fieldset
+        aria-describedby={ariaDescribedBy}
+        aria-invalid={invalid || undefined}
+        aria-labelledby={ariaLabelledBy}
+        aria-required={isRequired || undefined}
+        className={cn("grid gap-3", className)}
+        data-slot="date-range-input"
+        ref={ref}
+        {...props}
+      >
+        <div className="grid gap-3 md:grid-cols-[1fr_auto_1fr] md:items-end">
+          <div className="grid gap-2">
+            <Label htmlFor={startId}>{startLabel}</Label>
+            <DateInput
+              {...startProps}
+              aria-describedby={ariaDescribedBy}
+              aria-invalid={invalid || startProps?.["aria-invalid"]}
+              disabled={disabled || startProps?.disabled}
+              id={startId}
+              readOnly={readOnly || startProps?.readOnly}
+              required={isRequired || startProps?.required}
+            />
+          </div>
+          <span
+            aria-hidden="true"
+            className="hidden text-sm font-medium text-muted-foreground md:inline-flex md:pb-2"
+          >
+            {separator}
+          </span>
+          <div className="grid gap-2">
+            <Label htmlFor={endId}>{endLabel}</Label>
+            <DateInput
+              {...endProps}
+              aria-describedby={ariaDescribedBy}
+              aria-invalid={invalid || endProps?.["aria-invalid"]}
+              disabled={disabled || endProps?.disabled}
+              id={endId}
+              readOnly={readOnly || endProps?.readOnly}
+              required={isRequired || endProps?.required}
+            />
+          </div>
+        </div>
+      </fieldset>
+    );
+  },
+);
+
+DateRangeInput.displayName = "DateRangeInput";

--- a/packages/ui/src/components/numeric-input.test.tsx
+++ b/packages/ui/src/components/numeric-input.test.tsx
@@ -1,0 +1,25 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { NumericInput } from "./numeric-input.js";
+
+describe("NumericInput", () => {
+  it("renders a shared number input surface with numeric keyboard hints", () => {
+    const markup = renderToStaticMarkup(
+      <NumericInput id="match-order" max={32} min={1} step={1} />,
+    );
+
+    expect(markup).toContain('type="number"');
+    expect(markup).toContain('inputMode="numeric"');
+    expect(markup).toContain('min="1"');
+    expect(markup).toContain('max="32"');
+  });
+
+  it("switches to decimal input mode when the step allows fractional values", () => {
+    const markup = renderToStaticMarkup(
+      <NumericInput defaultValue={4.5} step="0.5" />,
+    );
+
+    expect(markup).toContain('inputMode="decimal"');
+    expect(markup).toContain('step="0.5"');
+  });
+});

--- a/packages/ui/src/components/numeric-input.tsx
+++ b/packages/ui/src/components/numeric-input.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { Input, type InputProps } from "./input.js";
+
+export interface NumericInputProps extends Omit<InputProps, "type"> {}
+
+function getDefaultInputMode(step: InputProps["step"]) {
+  if (typeof step === "number") {
+    return Number.isInteger(step) ? "numeric" : "decimal";
+  }
+
+  if (typeof step === "string") {
+    return step.includes(".") ? "decimal" : "numeric";
+  }
+
+  return "numeric";
+}
+
+export const NumericInput = React.forwardRef<
+  HTMLInputElement,
+  NumericInputProps
+>(({ inputMode, step, ...props }, ref) => (
+  <Input
+    inputMode={inputMode ?? getDefaultInputMode(step)}
+    ref={ref}
+    step={step}
+    type="number"
+    {...props}
+  />
+));
+
+NumericInput.displayName = "NumericInput";

--- a/packages/ui/src/date-input.stories.tsx
+++ b/packages/ui/src/date-input.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, userEvent } from "@storybook/test";
+import { DateInput } from "./components/date-input.js";
+import { Field } from "./components/field.js";
+
+const meta: Meta<typeof DateInput> = {
+  title: "Shared/Forms/Date Input",
+  component: DateInput,
+  tags: ["autodocs"],
+  args: {
+    defaultValue: "2026-05-10",
+  },
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Shared single-date primitive for native calendar-date entry. It stays intentionally close to browser date semantics while preserving the package's field, validation, and read-only conventions.",
+      },
+    },
+  },
+  render: (args) => <DateInput className="w-[240px]" {...args} />,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const input = canvasElement.querySelector('input[type="date"]');
+    if (!input) {
+      throw new Error("Expected date input to render");
+    }
+
+    await userEvent.tab();
+    await expect(input).toHaveFocus();
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    readOnly: true,
+  },
+};
+
+export const Invalid: Story = {
+  render: () => (
+    <Field
+      className="w-[240px]"
+      description="Use the first match-ready date confirmed with the venue."
+      error="Start date cannot be earlier than the registration close date."
+      label="Competition start date"
+      required
+    >
+      <DateInput defaultValue="2026-05-02" />
+    </Field>
+  ),
+};

--- a/packages/ui/src/date-range-input.stories.tsx
+++ b/packages/ui/src/date-range-input.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, userEvent, within } from "@storybook/test";
+import { DateRangeInput } from "./components/date-range-input.js";
+import { Field } from "./components/field.js";
+
+const meta: Meta<typeof DateRangeInput> = {
+  title: "Shared/Forms/Date Range Input",
+  component: DateRangeInput,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Shared paired-date surface for start and end windows. It keeps paired calendar fields inside one reusable contract so feature forms can map range values into TanStack Form without rebuilding accessibility and validation wiring.",
+      },
+    },
+  },
+  render: (args) => (
+    <DateRangeInput
+      className="w-[360px]"
+      endProps={{ defaultValue: "2026-05-12", name: "endDate" }}
+      startProps={{ defaultValue: "2026-05-01", name: "startDate" }}
+      {...args}
+    />
+  ),
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const start = canvas.getByLabelText(/start date/i);
+
+    await userEvent.tab();
+    await expect(start).toHaveFocus();
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    readOnly: true,
+  },
+};
+
+export const Invalid: Story = {
+  render: () => (
+    <Field
+      className="w-[420px]"
+      description="Keep these values as local date boundaries and let the feature form own any cross-field validation rules."
+      error="Registration end date must be on or after the start date."
+      label="Registration window"
+      required
+    >
+      <DateRangeInput
+        endProps={{ defaultValue: "2026-05-08", name: "endDate" }}
+        startProps={{ defaultValue: "2026-05-10", name: "startDate" }}
+      />
+    </Field>
+  ),
+};

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -4,8 +4,11 @@ import * as ui from "./index.js";
 describe("ui package exports", () => {
   it("exposes the foundation and selection control surfaces", () => {
     expect(ui.Button).toBeTruthy();
+    expect(ui.DateInput).toBeTruthy();
+    expect(ui.DateRangeInput).toBeTruthy();
     expect(ui.Field).toBeTruthy();
     expect(ui.Input).toBeTruthy();
+    expect(ui.NumericInput).toBeTruthy();
     expect(ui.Textarea).toBeTruthy();
     expect(ui.Checkbox).toBeTruthy();
     expect(ui.RadioGroup).toBeTruthy();

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -17,6 +17,12 @@ export {
 } from "./components/checkbox.js";
 export type { CheckboxProps } from "./components/checkbox.js";
 export {
+  DateInput,
+  type DateInputProps,
+} from "./components/date-input.js";
+export { DateRangeInput } from "./components/date-range-input.js";
+export type { DateRangeInputProps } from "./components/date-range-input.js";
+export {
   Dialog,
   DialogClose,
   DialogContent,
@@ -43,6 +49,10 @@ export { Input } from "./components/input.js";
 export type { InputProps } from "./components/input.js";
 export { Label } from "./components/label.js";
 export type { LabelProps } from "./components/label.js";
+export {
+  NumericInput,
+  type NumericInputProps,
+} from "./components/numeric-input.js";
 export {
   RadioGroup,
   RadioGroupItem,

--- a/packages/ui/src/numeric-input.stories.tsx
+++ b/packages/ui/src/numeric-input.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, userEvent, within } from "@storybook/test";
+import { Field } from "./components/field.js";
+import { NumericInput } from "./components/numeric-input.js";
+
+const meta: Meta<typeof NumericInput> = {
+  title: "Shared/Forms/Numeric Input",
+  component: NumericInput,
+  tags: ["autodocs"],
+  args: {
+    min: 1,
+    placeholder: "16",
+    step: 1,
+  },
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Shared numeric entry primitive for bounded counts, scores, and ordering values. It keeps native number semantics while preserving the shared invalid, disabled, and read-only styling contract.",
+      },
+    },
+  },
+  render: (args) => <NumericInput className="w-[220px]" {...args} />,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("spinbutton");
+
+    await userEvent.tab();
+    await expect(input).toHaveFocus();
+  },
+};
+
+export const DecimalStep: Story = {
+  args: {
+    defaultValue: 4.5,
+    placeholder: "4.5",
+    step: 0.5,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    defaultValue: 32,
+    disabled: true,
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    defaultValue: 24,
+    readOnly: true,
+  },
+};
+
+export const Invalid: Story = {
+  render: () => (
+    <Field
+      className="w-[220px]"
+      description="Use the seeded draw size approved by operations."
+      error="Player count must be at least 4 and divisible by 2."
+      label="Player count"
+      required
+    >
+      <NumericInput defaultValue={3} min={4} step={2} />
+    </Field>
+  ),
+};


### PR DESCRIPTION
## Summary
- add `NumericInput`, `DateInput`, and `DateRangeInput` to `@padel/ui`
- add Storybook stories and colocated tests for the new input surfaces
- sync backlog/sprint/UI-package docs for `TKT-029` and move issue `#29` into `In Sprint`

## Validation
- `pnpm --filter @padel/ui test`
- `pnpm --filter @padel/ui typecheck`
- `pnpm --filter @padel/ui lint`
- `pnpm --filter @padel/ui storybook:build`
- pre-push affected checks for `@padel/ui` and `@padel/web`

## Manual review
- Storybook dev server is running locally at `http://localhost:6006/`
