### PR TITLE
feat(ui): add summary and metadata display primitives

### DIFF
--- a/docs/09-agile/product-backlog.md
+++ b/docs/09-agile/product-backlog.md
@@ -506,3 +506,115 @@ For each ticket, include:
 - GitHub labels: `type:task`, `lane:frontend`, `area:ui-package`, `area:storybook`, `target:packages-ui`, `target:packages-config`
 - milestone/sprint: `next-ui-package-sprint`
 - GitHub issue URL or placeholder: `https://github.com/Damimd10/padel/issues/29`
+
+### TKT-030 - Add shared operational feedback primitives to the shared UI package
+
+- ID: `TKT-030`
+- type: `task`
+- epic: `ui-package-foundation`
+- delivery lane: `frontend`
+- affected apps/packages: `packages/ui`, `packages/config`
+- title: `Add shared operational feedback primitives in packages/ui`
+- story/task description: Add the shared feedback surfaces needed by operational workflows without pushing status semantics into app-local ad hoc markup. This ticket should introduce `Inline Alert`, `Toast`, and `Empty State` primitives that align with accessibility guidance, document when transient versus persistent feedback should be used, and keep workflow-specific resolution logic out of the shared package.
+- acceptance criteria:
+  - `packages/ui` exports reusable `Inline Alert`, `Toast`, and `Empty State` surfaces
+  - Storybook documents severity or status variants, empty-state usage guidance and the accessibility expectations for both transient and persistent messaging
+  - the shared package does not embed routing, data fetching or mutation logic into the feedback primitives
+  - the public APIs support the documented operational states relevant to admin workflows such as blocked, warning, success and informational messaging
+  - tests validate the critical public rendering and accessibility behavior of the shipped components
+- linked docs:
+  - `/docs/03-requirements/functional-requirements.md`
+  - `/docs/11-design-system/accessibility-guidelines.md`
+  - `/docs/11-design-system/component-inventory.md`
+  - `/docs/11-design-system/component-states.md`
+  - `/docs/11-design-system/storybook-documentation-strategy.md`
+  - `/docs/13-ui-package-storybook/storybook-guidelines.md`
+- linked ADRs:
+  - `/docs/07-adrs/adr-002-frontend-architecture.md`
+  - `/docs/07-adrs/adr-008-monorepo-tooling.md`
+  - `/docs/07-adrs/adr-009-testing-stack.md`
+- testing expectations:
+  - unit: validate severity or status variants plus accessibility-critical behavior such as alert semantics where relevant
+  - integration: verify feedback primitives remain package-local and can be consumed without coupling to app mutation or router layers
+  - e2e/manual: confirm Storybook distinguishes transient versus persistent messaging for operations-heavy workflows
+- estimate: `M`
+- status: `approved`
+- implementation workflow: `frontend`
+- GitHub labels: `type:task`, `lane:frontend`, `area:ui-package`, `area:storybook`, `target:packages-ui`, `target:packages-config`
+- milestone/sprint: `next-ui-package-sprint`
+- GitHub issue URL or placeholder: `https://github.com/Damimd10/padel/issues/30`
+
+### TKT-031 - Add shared summary and metadata display primitives to the shared UI package
+
+- ID: `TKT-031`
+- type: `task`
+- epic: `ui-package-foundation`
+- delivery lane: `frontend`
+- affected apps/packages: `packages/ui`, `packages/config`
+- title: `Add shared summary and metadata display primitives in packages/ui`
+- story/task description: Introduce the next shared data-display layer for admin-heavy screens before a full table abstraction is added. This ticket should add `Inline Metadata List`, `Key-Value Summary Block`, and `Progress Indicator` surfaces that make status and dense operational facts easy to render consistently across competition detail and review flows.
+- acceptance criteria:
+  - `packages/ui` exports reusable summary and metadata display primitives through the shared package entrypoint
+  - the components stay presentational and do not absorb domain-specific workflow rules or transport shapes
+  - Storybook documents dense, empty and status-relevant states where applicable
+  - the public APIs are explicit enough to support competition summaries, registration review context and result-entry support views without new ad hoc local patterns
+  - tests validate the public rendering contracts and any semantics that are part of the API
+- linked docs:
+  - `/docs/04-use-cases/use-cases.md`
+  - `/docs/11-design-system/component-inventory.md`
+  - `/docs/11-design-system/component-states.md`
+  - `/docs/11-design-system/ux-guidelines.md`
+  - `/docs/12-frontend-architecture/ui-composition.md`
+  - `/docs/13-ui-package-storybook/storybook-guidelines.md`
+  - `/docs/13-ui-package-storybook/summary-and-metadata-display.md`
+- linked ADRs:
+  - `/docs/07-adrs/adr-002-frontend-architecture.md`
+  - `/docs/07-adrs/adr-008-monorepo-tooling.md`
+  - `/docs/07-adrs/adr-009-testing-stack.md`
+- testing expectations:
+  - unit: validate rendering contracts, status variants and semantic output where relevant
+  - integration: verify display primitives remain stable shared building blocks with no app-specific data concerns
+  - e2e/manual: confirm Storybook examples cover dense admin usage rather than only marketing-style empty examples
+- estimate: `S`
+- status: `approved`
+- implementation workflow: `frontend`
+- GitHub labels: `type:task`, `lane:frontend`, `area:ui-package`, `area:storybook`, `target:packages-ui`, `target:packages-config`
+- milestone/sprint: `next-ui-package-sprint`
+- GitHub issue URL or placeholder: `https://github.com/Damimd10/padel/issues/31`
+
+### TKT-032 - Add shared table foundations for dense operational views to the shared UI package
+
+- ID: `TKT-032`
+- type: `task`
+- epic: `ui-package-foundation`
+- delivery lane: `frontend`
+- affected apps/packages: `packages/ui`, `packages/config`
+- title: `Add shared table foundations for dense operational views in packages/ui`
+- story/task description: Add the first shared table-oriented admin composite once the surrounding feedback and display primitives are in place. This ticket should introduce a reusable table foundation for dense operational views, including table structure, row-state support and Storybook guidance for empty, selected, warning and invalid row scenarios without turning the shared package into a workflow-specific data grid.
+- acceptance criteria:
+  - `packages/ui` exports reusable table foundations suitable for dense admin workflows
+  - row and table states cover the documented operational needs relevant to warning, invalid, selected and default rows
+  - Storybook documents accessibility, density and misuse guidance for the table API
+  - the shared API stays presentational and does not embed sorting, filtering, routing or server-state ownership
+  - tests validate the public rendering and semantics of the table foundation
+- linked docs:
+  - `/docs/03-requirements/functional-requirements.md`
+  - `/docs/11-design-system/accessibility-guidelines.md`
+  - `/docs/11-design-system/component-inventory.md`
+  - `/docs/11-design-system/component-states.md`
+  - `/docs/11-design-system/storybook-documentation-strategy.md`
+  - `/docs/12-frontend-architecture/ui-composition.md`
+- linked ADRs:
+  - `/docs/07-adrs/adr-002-frontend-architecture.md`
+  - `/docs/07-adrs/adr-008-monorepo-tooling.md`
+  - `/docs/07-adrs/adr-009-testing-stack.md`
+- testing expectations:
+  - unit: validate structural rendering and row-state semantics
+  - integration: verify the table foundations remain reusable shared UI rather than a route-owned data grid abstraction
+  - e2e/manual: confirm Storybook covers dense operational usage, empty states and row-state differences clearly
+- estimate: `M`
+- status: `approved`
+- implementation workflow: `frontend`
+- GitHub labels: `type:task`, `lane:frontend`, `area:ui-package`, `area:storybook`, `target:packages-ui`, `target:packages-config`
+- milestone/sprint: `next-ui-package-sprint`
+- GitHub issue URL or placeholder: `https://github.com/Damimd10/padel/issues/32`

--- a/docs/09-agile/sprint-plan.md
+++ b/docs/09-agile/sprint-plan.md
@@ -34,25 +34,32 @@ Every committed ticket must:
 - capacity assumptions:
   - the shared UI foundation, Storybook bootstrap, form foundations, choice controls, layout primitives, and overlay primitives are already delivered on `master`
   - the next highest-value UI-package gap for product workflows is the numeric and date-oriented input wave documented under `TKT-029`
-  - implementation should stay focused on shared input semantics and should not expand into feature-specific parsing, persistence, or async date-picker behavior
+  - implementation should stay focused on shared input semantics first, then expand into shared feedback and summary-display primitives without mixing in workflow-specific data shaping
 - committed tickets:
   - `TKT-029` - add advanced numeric and date-oriented form inputs in `packages/ui`
 - stretch tickets:
-  - none yet; keep the sprint focused on landing the numeric and date-oriented input contract cleanly before queueing the next shared-control wave
+  - `TKT-030` - add shared operational feedback primitives in `packages/ui`
+  - `TKT-031` - add shared summary and metadata display primitives in `packages/ui`
+  - `TKT-032` - add shared table foundations for dense operational views in `packages/ui`
 - lane balance across frontend / backend / infrastructure:
   - infrastructure: no sprint-critical infrastructure work is required for this wave
-  - frontend: `TKT-029` is the only committed UI-package item and should own the sprint focus
+  - frontend: `TKT-029` remains the committed UI-package item, with `TKT-030` and `TKT-031` as the next parallelizable display layers once the input baseline is stable
   - backend: no backend ticket is committed in this sprint snapshot
 - affected apps/packages summary:
   - `TKT-029`: `packages/ui`, `packages/config`
+  - `TKT-030`: `packages/ui`, `packages/config`
+  - `TKT-031`: `packages/ui`, `packages/config`
+  - `TKT-032`: `packages/ui`, `packages/config`
 - dependencies and blockers:
   - `TKT-029` depends on the delivered `Field` contract and previously shipped shared form primitives already present in `packages/ui`
   - `Date Range Input` must stay generic enough to map into TanStack Form without introducing app-owned business rules into `packages/ui`
+  - `TKT-031` should consume the shared status and feedback semantics clarified by `TKT-030` before hardening summary and progress display contracts
+  - `TKT-032` should follow the feedback and summary-display wave so table states inherit a stable operational vocabulary
 - GitHub milestone / project view used for execution:
   - milestone: `next-ui-package-sprint`
-  - project status: issue `#29` is in `Padel Delivery` with status `In Sprint`
+  - project status: issue `#29` is in `Padel Delivery` with status `In Sprint`, and issue `#31` is represented on the board as `Planned`
 - exit criteria:
   - `TKT-029` lands with shared exports, Storybook coverage, and tests for `Numeric Input`, `Date Input`, and `Date Range Input`
   - the shipped APIs remain generic and compose with `Field` without feature-specific parsing or submission logic
   - Storybook documents invalid, disabled, read-only, and keyboard-relevant states clearly enough for competition-configuration and result-entry forms
-  - GitHub execution state stays synced so the sprint doc, issue metadata, and project board all reflect the same committed work
+  - GitHub execution state stays synced so the sprint doc, issue metadata, and project board all reflect the same committed and planned work

--- a/docs/13-ui-package-storybook/summary-and-metadata-display.md
+++ b/docs/13-ui-package-storybook/summary-and-metadata-display.md
@@ -1,0 +1,90 @@
+# Summary and Metadata Display
+
+## Context
+
+Issue `TKT-024` / GitHub issue `#31` adds the next shared data-display wave for `packages/ui`.
+
+The target primitives are:
+
+- `Inline Metadata List`
+- `Key-Value Summary Block`
+- `Progress Indicator`
+
+These surfaces sit between lightweight feedback primitives and the upcoming table foundation. They must make dense operational context legible without dragging workflow logic into the shared UI package.
+
+## Assumptions
+
+- `TKT-023` should establish the shared operational feedback vocabulary before this ticket finalizes status-relevant display states.
+- Shared display primitives in `packages/ui` must remain presentational and must not own route data loading, rule evaluation, mutations, or workflow-specific actions.
+- The primary use case is operations-heavy product UI, so density and clarity matter more than decorative minimalism.
+- Shared APIs should accept data already shaped for display instead of raw DTOs or feature-specific transport objects.
+
+## Decisions
+
+### 1. Component scope and boundaries
+
+- `Inline Metadata List` is the compact surface for short operational facts such as date ranges, formats, owners, counts, and secondary statuses.
+- `Key-Value Summary Block` is the higher-density surface for grouped facts where labels and values need stronger hierarchy than a simple metadata row provides.
+- `Progress Indicator` is the shared progress surface for visible completion or step advancement, not a workflow engine or timeline orchestration layer.
+- None of these primitives should fetch data, derive workflow state, or decide whether a competition, registration, or result is healthy.
+- Domain-specific wrappers such as competition overview cards, registration review summaries, or result-entry support panels should stay in `apps/web` unless reuse is proven later.
+
+### 2. Public API direction
+
+- Shared APIs should prefer explicit display-oriented inputs such as `items`, `label`, `value`, `status`, `description`, `currentValue`, `maxValue`, or `steps` rather than ambiguous children-only contracts where structure matters.
+- `Inline Metadata List` should support typed item arrays and optional per-item emphasis or status styling without forcing consumers into one exact layout.
+- `Key-Value Summary Block` should support grouped key-value pairs, empty-value handling, and optional supporting description text while keeping label-value relationships semantically clear.
+- `Progress Indicator` should support both numeric progress and step-oriented progress when the rendered contract remains obvious in Storybook and tests.
+- If a variant or option exists only to express density, spacing, or emphasis, prefer composition-friendly classes or subcomponents over boolean prop accumulation.
+
+### 3. Accessibility and information hierarchy contract
+
+- Label-value relationships must remain understandable for assistive technology and not rely only on visual grid alignment.
+- Status-relevant emphasis should use text, iconography, or explicit labels in addition to color so blocked, pending, or complete states remain legible.
+- Dense metadata should preserve scanability by keeping labels visually subordinate to critical values and operational warnings.
+- `Progress Indicator` should expose semantic progress information where the public contract implies it, including accessible current-versus-total context.
+- Empty or unavailable values should be rendered intentionally so missing information does not look identical to a real zero or completed state.
+
+### 4. Storybook documentation contract
+
+Storybook for this wave should organize these components under `Shared/Data Display/...` and cover:
+
+- purpose and when-to-use guidance,
+- dense admin examples rather than only sparse marketing layouts,
+- empty or unavailable data handling,
+- status-relevant states when supported,
+- composition boundaries between primitive display surfaces and workflow-specific summary panels,
+- and misuse guidance, especially where a table or feature-owned composition is more appropriate.
+
+Recommended minimum stories:
+
+- `Inline Metadata List`: default, dense admin row, with emphasized item, empty or fallback values
+- `Key-Value Summary Block`: default, grouped summary, long-label handling, missing-value state
+- `Progress Indicator`: numeric progress, step-oriented progress if supported, blocked or warning-adjacent context, compact embedding example
+
+### 5. Testing contract
+
+- Unit coverage should validate rendering contracts, semantic label-value output, and status or progress states that are part of the public API.
+- Integration coverage should validate package entrypoint exports and ensure the primitives stay generic to presentation instead of accepting app-specific workflow objects.
+- Storybook interaction or assertion coverage should validate accessible progress output and any stateful display semantics that are exposed as part of the shared contract.
+- Tests should verify semantics and contract stability, not pixel-perfect implementation details.
+
+## Trade-offs
+
+- Explicit item-based APIs improve consistency and Storybook clarity, but they reduce the free-form flexibility of pure-children composition.
+- Supporting both numeric and step-oriented progress can make the API more useful across workflows, but it risks overloading one primitive if the display contract is not tightly defined.
+- Dense admin-oriented examples improve operational realism, but they require more careful docs to avoid encouraging shared components to absorb whole workflow panels.
+
+## Risks
+
+- If status semantics remain vague after `TKT-023`, this ticket could hard-code ad hoc warning or success styling that later conflicts with the feedback primitives.
+- If shared display components accept raw feature objects, `packages/ui` will accumulate transport-shape coupling and become harder to evolve.
+- If Storybook examples stay too sparse, reviewers may approve components that fail once real competition and review data becomes dense.
+- If `Progress Indicator` tries to cover timeline, progress bar, checklist, and workflow orchestration in one API, the component surface will become muddy quickly.
+
+## Next Actions
+
+- Use this document as the acceptance-review checklist for issue `#31`.
+- Keep `TKT-024` behind `TKT-023` where shared status language meaningfully affects display semantics.
+- When implementation starts, add Storybook docs that clearly separate display primitives from feature-owned competition or registration summary panels.
+- Follow this ticket with `TKT-025` only after the surrounding feedback and summary display vocabulary is stable.

--- a/docs/13-ui-package-storybook/ui-package-overview.md
+++ b/docs/13-ui-package-storybook/ui-package-overview.md
@@ -53,3 +53,4 @@ To keep `packages/ui` parallelizable without breaking package boundaries, the ne
 
 - `docs/13-ui-package-storybook/selection-choice-controls.md`
 - `docs/13-ui-package-storybook/numeric-date-inputs.md`
+- `docs/13-ui-package-storybook/summary-and-metadata-display.md`

--- a/packages/ui/src/components/inline-metadata-list.test.tsx
+++ b/packages/ui/src/components/inline-metadata-list.test.tsx
@@ -1,0 +1,29 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { InlineMetadataList } from "./inline-metadata-list.js";
+
+describe("InlineMetadataList", () => {
+  it("renders dense metadata items with labels and values", () => {
+    const markup = renderToStaticMarkup(
+      <InlineMetadataList
+        items={[
+          { label: "Format", value: "Round robin", emphasize: true },
+          { label: "Courts", value: "6" },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain('data-slot="inline-metadata-list"');
+    expect(markup).toContain('data-slot="inline-metadata-item"');
+    expect(markup).toContain("Round robin");
+    expect(markup).toContain("Courts");
+  });
+
+  it("renders the shared empty fallback for missing values", () => {
+    const markup = renderToStaticMarkup(
+      <InlineMetadataList items={[{ label: "Referee", value: null }]} />,
+    );
+
+    expect(markup).toContain("--");
+  });
+});

--- a/packages/ui/src/components/inline-metadata-list.tsx
+++ b/packages/ui/src/components/inline-metadata-list.tsx
@@ -1,0 +1,75 @@
+import type * as React from "react";
+import { cn } from "../lib/utils.js";
+
+const metadataToneClassNames = {
+  default: "text-foreground",
+  muted: "text-muted-foreground",
+  success: "text-primary",
+  warning: "text-accent-foreground",
+  danger: "text-destructive",
+} as const;
+
+export type InlineMetadataTone = keyof typeof metadataToneClassNames;
+
+export interface InlineMetadataItem {
+  id?: string;
+  label: React.ReactNode;
+  value?: React.ReactNode;
+  hint?: React.ReactNode;
+  tone?: InlineMetadataTone;
+  emphasize?: boolean;
+}
+
+export interface InlineMetadataListProps
+  extends React.HTMLAttributes<HTMLDListElement> {
+  emptyValue?: React.ReactNode;
+  items: InlineMetadataItem[];
+}
+
+export function InlineMetadataList({
+  className,
+  emptyValue = "--",
+  items,
+  ...props
+}: InlineMetadataListProps) {
+  return (
+    <dl
+      className={cn(
+        "flex flex-wrap gap-x-6 gap-y-4 rounded-2xl border border-border/70 bg-card/70 px-4 py-3",
+        className,
+      )}
+      data-slot="inline-metadata-list"
+      {...props}
+    >
+      {items.map((item, index) => {
+        const tone = item.tone ?? "default";
+
+        return (
+          <div
+            className="grid min-w-[7rem] gap-1"
+            data-slot="inline-metadata-item"
+            key={item.id ?? index}
+          >
+            <dt className="text-[0.7rem] font-medium tracking-[0.16em] text-muted-foreground uppercase">
+              {item.label}
+            </dt>
+            <dd
+              className={cn(
+                "text-sm leading-5",
+                metadataToneClassNames[tone],
+                item.emphasize ? "text-base font-semibold" : "font-medium",
+              )}
+            >
+              {item.value ?? emptyValue}
+            </dd>
+            {item.hint ? (
+              <dd className="text-xs leading-5 text-muted-foreground">
+                {item.hint}
+              </dd>
+            ) : null}
+          </div>
+        );
+      })}
+    </dl>
+  );
+}

--- a/packages/ui/src/components/key-value-summary-block.test.tsx
+++ b/packages/ui/src/components/key-value-summary-block.test.tsx
@@ -1,0 +1,31 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { KeyValueSummaryBlock } from "./key-value-summary-block.js";
+
+describe("KeyValueSummaryBlock", () => {
+  it("renders summary items with heading structure", () => {
+    const markup = renderToStaticMarkup(
+      <KeyValueSummaryBlock
+        description="Shared operational facts only."
+        heading="Registration summary"
+        items={[
+          { label: "Approved pairs", value: "18 teams" },
+          { label: "Missing waivers", value: "2 players", tone: "warning" },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain('data-slot="key-value-summary-block"');
+    expect(markup).toContain('data-slot="key-value-summary-grid"');
+    expect(markup).toContain("Registration summary");
+    expect(markup).toContain("18 teams");
+  });
+
+  it("renders the empty fallback when a value is unavailable", () => {
+    const markup = renderToStaticMarkup(
+      <KeyValueSummaryBlock items={[{ label: "Review owner" }]} />,
+    );
+
+    expect(markup).toContain("--");
+  });
+});

--- a/packages/ui/src/components/key-value-summary-block.tsx
+++ b/packages/ui/src/components/key-value-summary-block.tsx
@@ -1,0 +1,110 @@
+import type * as React from "react";
+import { cn } from "../lib/utils.js";
+
+const summaryToneClassNames = {
+  default: "text-foreground",
+  muted: "text-muted-foreground",
+  success: "text-primary",
+  warning: "text-accent-foreground",
+  danger: "text-destructive",
+} as const;
+
+const summaryColumnClassNames = {
+  1: "grid-cols-1",
+  2: "grid-cols-1 md:grid-cols-2",
+  3: "grid-cols-1 md:grid-cols-3",
+} as const;
+
+export type SummaryTone = keyof typeof summaryToneClassNames;
+
+export interface KeyValueSummaryItem {
+  id?: string;
+  label: React.ReactNode;
+  value?: React.ReactNode;
+  description?: React.ReactNode;
+  tone?: SummaryTone;
+}
+
+export interface KeyValueSummaryBlockProps
+  extends React.HTMLAttributes<HTMLElement> {
+  columns?: keyof typeof summaryColumnClassNames;
+  description?: React.ReactNode;
+  emptyValue?: React.ReactNode;
+  heading?: React.ReactNode;
+  items: KeyValueSummaryItem[];
+}
+
+export function KeyValueSummaryBlock({
+  className,
+  columns = 2,
+  description,
+  emptyValue = "--",
+  heading,
+  items,
+  ...props
+}: KeyValueSummaryBlockProps) {
+  return (
+    <section
+      className={cn(
+        "rounded-2xl border border-border/80 bg-card text-card-foreground shadow-sm",
+        className,
+      )}
+      data-slot="key-value-summary-block"
+      {...props}
+    >
+      {heading || description ? (
+        <header
+          className="border-b border-border/70 px-5 py-4"
+          data-slot="key-value-summary-header"
+        >
+          {heading ? (
+            <h3 className="text-sm font-semibold tracking-[0.08em] uppercase">
+              {heading}
+            </h3>
+          ) : null}
+          {description ? (
+            <p className="mt-1 text-sm leading-6 text-muted-foreground">
+              {description}
+            </p>
+          ) : null}
+        </header>
+      ) : null}
+      <dl
+        className={cn(
+          "grid gap-4 px-5 py-4",
+          summaryColumnClassNames[columns],
+        )}
+        data-slot="key-value-summary-grid"
+      >
+        {items.map((item, index) => {
+          const tone = item.tone ?? "default";
+
+          return (
+            <div
+              className="grid gap-1"
+              data-slot="key-value-summary-item"
+              key={item.id ?? index}
+            >
+              <dt className="text-xs font-medium tracking-[0.14em] text-muted-foreground uppercase">
+                {item.label}
+              </dt>
+              <dd
+                className={cn(
+                  "text-base font-semibold leading-6",
+                  summaryToneClassNames[tone],
+                )}
+              >
+                {item.value ?? emptyValue}
+              </dd>
+              {item.description ? (
+                <dd className="text-sm leading-6 text-muted-foreground">
+                  {item.description}
+                </dd>
+              ) : null}
+            </div>
+          );
+        })}
+      </dl>
+    </section>
+  );
+}

--- a/packages/ui/src/components/key-value-summary-block.tsx
+++ b/packages/ui/src/components/key-value-summary-block.tsx
@@ -70,10 +70,7 @@ export function KeyValueSummaryBlock({
         </header>
       ) : null}
       <dl
-        className={cn(
-          "grid gap-4 px-5 py-4",
-          summaryColumnClassNames[columns],
-        )}
+        className={cn("grid gap-4 px-5 py-4", summaryColumnClassNames[columns])}
         data-slot="key-value-summary-grid"
       >
         {items.map((item, index) => {

--- a/packages/ui/src/components/progress-indicator.test.tsx
+++ b/packages/ui/src/components/progress-indicator.test.tsx
@@ -1,0 +1,25 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ProgressIndicator } from "./progress-indicator.js";
+
+describe("ProgressIndicator", () => {
+  it("renders accessible progress semantics", () => {
+    const markup = renderToStaticMarkup(
+      <ProgressIndicator label="Registration review" max={12} value={9} />,
+    );
+
+    expect(markup).toContain('data-slot="progress-indicator"');
+    expect(markup).toContain('role="progressbar"');
+    expect(markup).toContain('aria-valuenow="9"');
+    expect(markup).toContain('aria-valuemax="12"');
+  });
+
+  it("clamps progress values beyond the allowed range", () => {
+    const markup = renderToStaticMarkup(
+      <ProgressIndicator label="Validation" max={5} value={9} />,
+    );
+
+    expect(markup).toContain('aria-valuenow="5"');
+    expect(markup).toContain("100%");
+  });
+});

--- a/packages/ui/src/components/progress-indicator.tsx
+++ b/packages/ui/src/components/progress-indicator.tsx
@@ -1,0 +1,99 @@
+import type * as React from "react";
+import { cn } from "../lib/utils.js";
+
+const progressToneClassNames = {
+  default: "bg-primary",
+  muted: "bg-muted-foreground",
+  success: "bg-primary",
+  warning: "bg-accent-foreground",
+  danger: "bg-destructive",
+} as const;
+
+const progressTextToneClassNames = {
+  default: "text-foreground",
+  muted: "text-muted-foreground",
+  success: "text-primary",
+  warning: "text-accent-foreground",
+  danger: "text-destructive",
+} as const;
+
+export type ProgressIndicatorTone = keyof typeof progressToneClassNames;
+
+export interface ProgressIndicatorProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  description?: React.ReactNode;
+  label: React.ReactNode;
+  max?: number;
+  tone?: ProgressIndicatorTone;
+  value: number;
+  valueLabel?: React.ReactNode;
+}
+
+export function ProgressIndicator({
+  className,
+  description,
+  label,
+  max = 100,
+  tone = "default",
+  value,
+  valueLabel,
+  ...props
+}: ProgressIndicatorProps) {
+  const safeMax = max > 0 ? max : 100;
+  const clampedValue = Math.min(Math.max(value, 0), safeMax);
+  const percent = Math.round((clampedValue / safeMax) * 100);
+  const resolvedValueLabel = valueLabel ?? `${percent}%`;
+  const ariaValueText =
+    typeof resolvedValueLabel === "string" ? resolvedValueLabel : `${percent}%`;
+
+  return (
+    <div
+      className={cn(
+        "grid gap-3 rounded-2xl border border-border/80 bg-card px-4 py-4 shadow-sm",
+        className,
+      )}
+      data-slot="progress-indicator"
+      {...props}
+    >
+      <div
+        className="flex items-start justify-between gap-4"
+        data-slot="progress-indicator-header"
+      >
+        <div className="grid gap-1">
+          <div className="text-sm font-semibold">{label}</div>
+          {description ? (
+            <p className="text-sm leading-6 text-muted-foreground">
+              {description}
+            </p>
+          ) : null}
+        </div>
+        <div
+          className={cn(
+            "text-sm font-semibold whitespace-nowrap",
+            progressTextToneClassNames[tone],
+          )}
+        >
+          {resolvedValueLabel}
+        </div>
+      </div>
+      <div
+        aria-valuemax={safeMax}
+        aria-valuemin={0}
+        aria-valuenow={clampedValue}
+        aria-valuetext={ariaValueText}
+        className="h-2.5 overflow-hidden rounded-full bg-muted"
+        data-slot="progress-indicator-track"
+        role="progressbar"
+      >
+        <div
+          className={cn(
+            "h-full rounded-full transition-[width]",
+            progressToneClassNames[tone],
+          )}
+          data-slot="progress-indicator-fill"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/progress-indicator.tsx
+++ b/packages/ui/src/components/progress-indicator.tsx
@@ -84,6 +84,7 @@ export function ProgressIndicator({
         className="h-2.5 overflow-hidden rounded-full bg-muted"
         data-slot="progress-indicator-track"
         role="progressbar"
+        tabIndex={0}
       >
         <div
           className={cn(

--- a/packages/ui/src/index.test.tsx
+++ b/packages/ui/src/index.test.tsx
@@ -36,8 +36,12 @@ describe("ui package entrypoint", () => {
   it("exports data-display primitives for shared package consumption", () => {
     const markup = renderToStaticMarkup(
       <>
-        <InlineMetadataList items={[{ label: "Format", value: "Round robin" }]} />
-        <KeyValueSummaryBlock items={[{ label: "Registered pairs", value: "16" }]} />
+        <InlineMetadataList
+          items={[{ label: "Format", value: "Round robin" }]}
+        />
+        <KeyValueSummaryBlock
+          items={[{ label: "Registered pairs", value: "16" }]}
+        />
         <ProgressIndicator label="Review progress" max={10} value={7} />
       </>,
     );

--- a/packages/ui/src/index.test.tsx
+++ b/packages/ui/src/index.test.tsx
@@ -3,8 +3,11 @@ import { describe, expect, it } from "vitest";
 import {
   EmptyState,
   InlineAlert,
+  InlineMetadataList,
   Input,
+  KeyValueSummaryBlock,
   Label,
+  ProgressIndicator,
   Textarea,
   ToastProvider,
 } from "./index.js";
@@ -28,5 +31,19 @@ describe("ui package entrypoint", () => {
     expect(markup).toContain('data-slot="textarea"');
     expect(markup).toContain('data-slot="inline-alert"');
     expect(markup).toContain('data-slot="empty-state"');
+  });
+
+  it("exports data-display primitives for shared package consumption", () => {
+    const markup = renderToStaticMarkup(
+      <>
+        <InlineMetadataList items={[{ label: "Format", value: "Round robin" }]} />
+        <KeyValueSummaryBlock items={[{ label: "Registered pairs", value: "16" }]} />
+        <ProgressIndicator label="Review progress" max={10} value={7} />
+      </>,
+    );
+
+    expect(markup).toContain('data-slot="inline-metadata-list"');
+    expect(markup).toContain('data-slot="key-value-summary-block"');
+    expect(markup).toContain('data-slot="progress-indicator"');
   });
 });

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -75,12 +75,29 @@ export { Field } from "./components/field.js";
 export type { FieldProps } from "./components/field.js";
 export { Input } from "./components/input.js";
 export type { InputProps } from "./components/input.js";
+export {
+  InlineMetadataList,
+  type InlineMetadataItem,
+  type InlineMetadataListProps,
+  type InlineMetadataTone,
+} from "./components/inline-metadata-list.js";
+export {
+  KeyValueSummaryBlock,
+  type KeyValueSummaryBlockProps,
+  type KeyValueSummaryItem,
+  type SummaryTone,
+} from "./components/key-value-summary-block.js";
 export { Label } from "./components/label.js";
 export type { LabelProps } from "./components/label.js";
 export {
   NumericInput,
   type NumericInputProps,
 } from "./components/numeric-input.js";
+export {
+  ProgressIndicator,
+  type ProgressIndicatorProps,
+  type ProgressIndicatorTone,
+} from "./components/progress-indicator.js";
 export {
   RadioGroup,
   RadioGroupItem,

--- a/packages/ui/src/inline-metadata-list.stories.tsx
+++ b/packages/ui/src/inline-metadata-list.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { InlineMetadataList } from "./components/inline-metadata-list.js";
+
+const meta: Meta<typeof InlineMetadataList> = {
+  title: "Shared/Data Display/Inline Metadata List",
+  component: InlineMetadataList,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Compact operational facts for competition and review surfaces. Keep the component focused on concise metadata rather than turning it into a full workflow panel.",
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <InlineMetadataList
+      className="w-[760px] max-w-full"
+      items={[
+        { label: "Format", value: "Round robin", emphasize: true },
+        { label: "Registration window", value: "May 4 to May 19" },
+        { label: "Court cluster", value: "North club" },
+        { label: "Organizer", value: "Damian Medina" },
+      ]}
+    />
+  ),
+};
+
+export const DenseAdminRow: Story = {
+  render: () => (
+    <InlineMetadataList
+      className="w-[860px] max-w-full"
+      items={[
+        { label: "Competition", value: "Autumn League A", emphasize: true },
+        { label: "Pairs approved", value: "18 of 24", tone: "success" },
+        { label: "Needs review", value: "3 registrations", tone: "warning" },
+        { label: "Results pending", value: "2 matches", tone: "danger" },
+        { label: "Last sync", value: "4 minutes ago", tone: "muted" },
+      ]}
+    />
+  ),
+};
+
+export const WithFallbackValues: Story = {
+  render: () => (
+    <InlineMetadataList
+      className="w-[720px] max-w-full"
+      items={[
+        { label: "Lead referee", value: "Marina Costa" },
+        { label: "Weather plan" },
+        {
+          label: "Player notes",
+          hint: "No note is better than ambiguous note text in dense admin UI.",
+        },
+      ]}
+    />
+  ),
+};

--- a/packages/ui/src/key-value-summary-block.stories.tsx
+++ b/packages/ui/src/key-value-summary-block.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { KeyValueSummaryBlock } from "./components/key-value-summary-block.js";
+
+const meta: Meta<typeof KeyValueSummaryBlock> = {
+  title: "Shared/Data Display/Key-Value Summary Block",
+  component: KeyValueSummaryBlock,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Grouped summary facts for admin-heavy panels where labels and values need stronger hierarchy than an inline metadata strip.",
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <KeyValueSummaryBlock
+      className="w-[760px] max-w-full"
+      description="Use shared summary blocks for presentational facts, then compose workflow actions around them in app space."
+      heading="Competition overview"
+      items={[
+        {
+          label: "Registration status",
+          value: "Review in progress",
+          description: "Three participants still need manual category confirmation.",
+          tone: "warning",
+        },
+        {
+          label: "Approved pairs",
+          value: "18",
+          description: "Ready for draw generation once waivers are complete.",
+        },
+        {
+          label: "Payment exceptions",
+          value: "2",
+          description: "Flagged for organizer follow-up.",
+          tone: "danger",
+        },
+        {
+          label: "Last reviewed",
+          value: "Today, 14:10",
+          description: "Synced from the review queue summary.",
+          tone: "muted",
+        },
+      ]}
+    />
+  ),
+};
+
+export const ThreeColumnLayout: Story = {
+  render: () => (
+    <KeyValueSummaryBlock
+      className="w-[860px] max-w-full"
+      columns={3}
+      heading="Operations footprint"
+      items={[
+        { label: "Main draw", value: "16 pairs" },
+        { label: "Qualifying", value: "8 pairs" },
+        { label: "Reserve list", value: "5 pairs" },
+        { label: "Guaranteed courts", value: "4" },
+        { label: "Confirmed officials", value: "3" },
+        { label: "Medical support", value: "Pending", tone: "warning" },
+      ]}
+    />
+  ),
+};
+
+export const MissingValueState: Story = {
+  render: () => (
+    <KeyValueSummaryBlock
+      className="w-[720px] max-w-full"
+      heading="Registration exception"
+      items={[
+        { label: "Review owner", value: "Lucia Perez" },
+        { label: "Escalation reason" },
+        { label: "Supporting evidence", value: "Awaiting player response" },
+      ]}
+    />
+  ),
+};

--- a/packages/ui/src/key-value-summary-block.stories.tsx
+++ b/packages/ui/src/key-value-summary-block.stories.tsx
@@ -30,7 +30,8 @@ export const Default: Story = {
         {
           label: "Registration status",
           value: "Review in progress",
-          description: "Three participants still need manual category confirmation.",
+          description:
+            "Three participants still need manual category confirmation.",
           tone: "warning",
         },
         {

--- a/packages/ui/src/progress-indicator.stories.tsx
+++ b/packages/ui/src/progress-indicator.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ProgressIndicator } from "./components/progress-indicator.js";
+
+const meta: Meta<typeof ProgressIndicator> = {
+  title: "Shared/Data Display/Progress Indicator",
+  component: ProgressIndicator,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Accessible shared progress feedback for operational workflows. Keep state calculation in feature code and pass already-shaped progress facts into the primitive.",
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const NumericProgress: Story = {
+  render: () => (
+    <ProgressIndicator
+      className="w-[420px]"
+      description="Nine of twelve registrations have a final review decision."
+      label="Registration review"
+      max={12}
+      value={9}
+      valueLabel="9 of 12 reviewed"
+    />
+  ),
+};
+
+export const WarningState: Story = {
+  render: () => (
+    <ProgressIndicator
+      className="w-[420px]"
+      description="Scheduling cannot finish until every result is validated."
+      label="Result validation"
+      max={18}
+      tone="warning"
+      value={12}
+      valueLabel="6 matches still pending"
+    />
+  ),
+};
+
+export const CompleteState: Story = {
+  render: () => (
+    <ProgressIndicator
+      className="w-[420px]"
+      description="This shared primitive can sit inside richer app-level completion panels later."
+      label="Division setup"
+      max={5}
+      tone="success"
+      value={5}
+      valueLabel="All 5 divisions confirmed"
+    />
+  ),
+};


### PR DESCRIPTION
## Summary
- add shared `InlineMetadataList`, `KeyValueSummaryBlock`, and `ProgressIndicator` primitives in `packages/ui`
- add Storybook stories and colocated tests for the new data-display surfaces
- document the new summary-display wave in backlog and Storybook contract docs

## Testing
- not run locally in this worktree because `node_modules` are missing, so `vitest`, `biome`, and `nx`-backed hooks are unavailable

Closes #31