### PR TITLE
feat(ui): add shared table foundations

### DIFF
--- a/packages/ui/src/components/table.test.tsx
+++ b/packages/ui/src/components/table.test.tsx
@@ -1,0 +1,97 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableEmptyState,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableRowHeader,
+} from "./table.js";
+
+describe("Table", () => {
+  it("renders semantic structure for shared dense admin views", () => {
+    const markup = renderToStaticMarkup(
+      <Table aria-label="Competition review table">
+        <TableCaption>Presentational table foundations only.</TableCaption>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Competition</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Updated</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow state="selected">
+            <TableRowHeader>Autumn League</TableRowHeader>
+            <TableCell>Selected for bulk publish</TableCell>
+            <TableCell>Today, 14:10</TableCell>
+          </TableRow>
+          <TableRow state="warning">
+            <TableRowHeader>Junior Open</TableRowHeader>
+            <TableCell>2 waivers missing</TableCell>
+            <TableCell>8 minutes ago</TableCell>
+          </TableRow>
+        </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableCell colSpan={3}>2 competitions shown</TableCell>
+          </TableRow>
+        </TableFooter>
+      </Table>,
+    );
+
+    expect(markup).toContain('data-slot="table"');
+    expect(markup).toContain('data-slot="table-caption"');
+    expect(markup).toContain('data-slot="table-header"');
+    expect(markup).toContain('data-slot="table-body"');
+    expect(markup).toContain('data-slot="table-footer"');
+    expect(markup).toContain('data-state="selected"');
+    expect(markup).toContain('aria-selected="true"');
+    expect(markup).toContain('scope="col"');
+    expect(markup).toContain('scope="row"');
+  });
+
+  it("supports a reusable empty-state row without workflow-specific behavior", () => {
+    const markup = renderToStaticMarkup(
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableEmptyState
+              colSpan={4}
+              description="Add filters or load data in app space before promoting more behavior."
+              eyebrow="Empty table"
+              title="No registrations need review"
+            />
+          </TableRow>
+        </TableBody>
+      </Table>,
+    );
+
+    expect(markup).toContain('data-slot="table-empty-state"');
+    expect(markup).toContain('colSpan="4"');
+    expect(markup).toContain("No registrations need review");
+    expect(markup).toContain("Add filters or load data in app space");
+  });
+
+  it("marks invalid rows without relying on color-only signaling", () => {
+    const markup = renderToStaticMarkup(
+      <Table>
+        <TableBody>
+          <TableRow aria-label="Invalid registration row" state="invalid">
+            <TableRowHeader>Pair 18</TableRowHeader>
+            <TableCell>Invalid medical certificate</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>,
+    );
+
+    expect(markup).toContain('data-state="invalid"');
+    expect(markup).toContain("Invalid medical certificate");
+    expect(markup).toContain('aria-label="Invalid registration row"');
+  });
+});

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -1,0 +1,243 @@
+import { type VariantProps, cva } from "class-variance-authority";
+import * as React from "react";
+import { cn } from "../lib/utils.js";
+import {
+  EmptyState,
+  EmptyStateDescription,
+  EmptyStateEyebrow,
+  EmptyStateTitle,
+} from "./empty-state.js";
+
+const tableRowVariants = cva(
+  "border-b border-border/70 transition-colors last:border-b-0 focus-within:relative focus-within:z-10 focus-within:shadow-[inset_0_0_0_2px_hsl(var(--ring)/0.2)]",
+  {
+    variants: {
+      state: {
+        default: "bg-transparent text-foreground",
+        selected:
+          "bg-secondary/70 text-secondary-foreground shadow-[inset_0_0_0_1px_hsl(var(--primary)/0.2)]",
+        warning:
+          "bg-accent/55 text-foreground shadow-[inset_4px_0_0_0_hsl(var(--accent-foreground)/0.28)]",
+        invalid:
+          "bg-destructive/6 text-foreground shadow-[inset_4px_0_0_0_hsl(var(--destructive)/0.5)]",
+        completed:
+          "bg-primary/6 text-foreground shadow-[inset_4px_0_0_0_hsl(var(--primary)/0.3)]",
+      },
+    },
+    defaultVariants: {
+      state: "default",
+    },
+  },
+);
+
+export type TableRowState = NonNullable<
+  VariantProps<typeof tableRowVariants>["state"]
+>;
+
+export interface TableProps
+  extends React.TableHTMLAttributes<HTMLTableElement> {}
+
+export const Table = React.forwardRef<HTMLTableElement, TableProps>(
+  ({ className, ...props }, ref) => (
+    <table
+      className={cn(
+        "w-full min-w-[40rem] border-separate border-spacing-0 text-left text-sm leading-5",
+        className,
+      )}
+      data-slot="table"
+      ref={ref}
+      {...props}
+    />
+  ),
+);
+
+Table.displayName = "Table";
+
+export interface TableHeaderProps
+  extends React.HTMLAttributes<HTMLTableSectionElement> {}
+
+export const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  TableHeaderProps
+>(({ className, ...props }, ref) => (
+  <thead
+    className={cn("[&_tr]:border-b [&_tr]:border-border/80", className)}
+    data-slot="table-header"
+    ref={ref}
+    {...props}
+  />
+));
+
+TableHeader.displayName = "TableHeader";
+
+export interface TableBodyProps
+  extends React.HTMLAttributes<HTMLTableSectionElement> {}
+
+export const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  TableBodyProps
+>(({ className, ...props }, ref) => (
+  <tbody
+    className={cn("[&_tr:last-child]:border-b-0", className)}
+    data-slot="table-body"
+    ref={ref}
+    {...props}
+  />
+));
+
+TableBody.displayName = "TableBody";
+
+export interface TableFooterProps
+  extends React.HTMLAttributes<HTMLTableSectionElement> {}
+
+export const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  TableFooterProps
+>(({ className, ...props }, ref) => (
+  <tfoot
+    className={cn(
+      "bg-muted/40 font-medium text-foreground [&>tr]:border-t [&>tr]:border-border/80",
+      className,
+    )}
+    data-slot="table-footer"
+    ref={ref}
+    {...props}
+  />
+));
+
+TableFooter.displayName = "TableFooter";
+
+export interface TableRowProps
+  extends React.HTMLAttributes<HTMLTableRowElement>,
+    VariantProps<typeof tableRowVariants> {}
+
+export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
+  ({ className, state, ...props }, ref) => (
+    <tr
+      aria-selected={
+        props["aria-selected"] ?? (state === "selected" || undefined)
+      }
+      className={cn(tableRowVariants({ className, state }))}
+      data-slot="table-row"
+      data-state={state ?? "default"}
+      ref={ref}
+      {...props}
+    />
+  ),
+);
+
+TableRow.displayName = "TableRow";
+
+export interface TableHeadProps
+  extends React.ThHTMLAttributes<HTMLTableCellElement> {}
+
+export const TableHead = React.forwardRef<HTMLTableCellElement, TableHeadProps>(
+  ({ className, scope, ...props }, ref) => (
+    <th
+      className={cn(
+        "h-12 border-b border-border/70 px-4 py-3 text-left align-middle text-[0.72rem] font-semibold tracking-[0.18em] text-muted-foreground uppercase",
+        className,
+      )}
+      data-slot="table-head"
+      ref={ref}
+      scope={scope ?? "col"}
+      {...props}
+    />
+  ),
+);
+
+TableHead.displayName = "TableHead";
+
+export interface TableRowHeaderProps
+  extends React.ThHTMLAttributes<HTMLTableCellElement> {}
+
+export const TableRowHeader = React.forwardRef<
+  HTMLTableCellElement,
+  TableRowHeaderProps
+>(({ className, scope, ...props }, ref) => (
+  <th
+    className={cn(
+      "border-b border-border/70 px-4 py-3.5 text-left align-middle font-medium text-foreground",
+      className,
+    )}
+    data-slot="table-row-header"
+    ref={ref}
+    scope={scope ?? "row"}
+    {...props}
+  />
+));
+
+TableRowHeader.displayName = "TableRowHeader";
+
+export interface TableCellProps
+  extends React.TdHTMLAttributes<HTMLTableCellElement> {}
+
+export const TableCell = React.forwardRef<HTMLTableCellElement, TableCellProps>(
+  ({ className, ...props }, ref) => (
+    <td
+      className={cn(
+        "border-b border-border/70 px-4 py-3.5 align-middle text-foreground",
+        className,
+      )}
+      data-slot="table-cell"
+      ref={ref}
+      {...props}
+    />
+  ),
+);
+
+TableCell.displayName = "TableCell";
+
+export interface TableCaptionProps
+  extends React.HTMLAttributes<HTMLTableCaptionElement> {}
+
+export const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  TableCaptionProps
+>(({ className, ...props }, ref) => (
+  <caption
+    className={cn(
+      "caption-bottom px-4 pt-3 text-left text-sm leading-6 text-muted-foreground",
+      className,
+    )}
+    data-slot="table-caption"
+    ref={ref}
+    {...props}
+  />
+));
+
+TableCaption.displayName = "TableCaption";
+
+export interface TableEmptyStateProps
+  extends Omit<
+    React.TdHTMLAttributes<HTMLTableCellElement>,
+    "children" | "title"
+  > {
+  colSpan: number;
+  description?: React.ReactNode;
+  eyebrow?: React.ReactNode;
+  title: React.ReactNode;
+}
+
+export const TableEmptyState = React.forwardRef<
+  HTMLTableCellElement,
+  TableEmptyStateProps
+>(({ className, colSpan, description, eyebrow, title, ...props }, ref) => (
+  <td
+    className={cn("px-4 py-6", className)}
+    colSpan={colSpan}
+    data-slot="table-empty-state"
+    ref={ref}
+    {...props}
+  >
+    <EmptyState className="mx-auto max-w-2xl" size="compact">
+      {eyebrow ? <EmptyStateEyebrow>{eyebrow}</EmptyStateEyebrow> : null}
+      <EmptyStateTitle>{title}</EmptyStateTitle>
+      {description ? (
+        <EmptyStateDescription>{description}</EmptyStateDescription>
+      ) : null}
+    </EmptyState>
+  </td>
+));
+
+TableEmptyState.displayName = "TableEmptyState";

--- a/packages/ui/src/index.test.ts
+++ b/packages/ui/src/index.test.ts
@@ -15,5 +15,8 @@ describe("ui package exports", () => {
     expect(ui.Select).toBeTruthy();
     expect(ui.SelectTrigger).toBeTruthy();
     expect(ui.Switch).toBeTruthy();
+    expect(ui.Table).toBeTruthy();
+    expect(ui.TableRow).toBeTruthy();
+    expect(ui.TableEmptyState).toBeTruthy();
   });
 });

--- a/packages/ui/src/index.test.tsx
+++ b/packages/ui/src/index.test.tsx
@@ -8,6 +8,14 @@ import {
   KeyValueSummaryBlock,
   Label,
   ProgressIndicator,
+  Table,
+  TableBody,
+  TableCell,
+  TableEmptyState,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableRowHeader,
   Textarea,
   ToastProvider,
 } from "./index.js";
@@ -43,11 +51,29 @@ describe("ui package entrypoint", () => {
           items={[{ label: "Registered pairs", value: "16" }]}
         />
         <ProgressIndicator label="Review progress" max={10} value={7} />
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow state="warning">
+              <TableRowHeader>Review queue</TableRowHeader>
+              <TableCell>3 pending</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableEmptyState colSpan={2} title="No archived competitions" />
+            </TableRow>
+          </TableBody>
+        </Table>
       </>,
     );
 
     expect(markup).toContain('data-slot="inline-metadata-list"');
     expect(markup).toContain('data-slot="key-value-summary-block"');
     expect(markup).toContain('data-slot="progress-indicator"');
+    expect(markup).toContain('data-slot="table"');
+    expect(markup).toContain('data-slot="table-empty-state"');
   });
 });

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -71,6 +71,31 @@ export {
   type SeparatorProps,
 } from "./components/separator.js";
 export { Skeleton } from "./components/skeleton.js";
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableEmptyState,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableRowHeader,
+} from "./components/table.js";
+export type {
+  TableBodyProps,
+  TableCaptionProps,
+  TableCellProps,
+  TableEmptyStateProps,
+  TableFooterProps,
+  TableHeadProps,
+  TableHeaderProps,
+  TableProps,
+  TableRowHeaderProps,
+  TableRowProps,
+  TableRowState,
+} from "./components/table.js";
 export { Field } from "./components/field.js";
 export type { FieldProps } from "./components/field.js";
 export { Input } from "./components/input.js";

--- a/packages/ui/src/table.stories.tsx
+++ b/packages/ui/src/table.stories.tsx
@@ -1,0 +1,178 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableEmptyState,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableRowHeader,
+} from "./components/table.js";
+
+const meta: Meta<typeof Table> = {
+  title: "Shared/Data Display/Table",
+  component: Table,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: `
+Purpose
+Semantic table foundations for dense operational views in admin-heavy workflows.
+
+When to use
+Use this shared surface when rows and columns already exist in product language and app code can shape the data before rendering.
+
+When not to use
+Do not push sorting, filtering, pagination, route state, mutations, or workflow-specific action orchestration into this API. Compose those concerns outside \`packages/ui\`.
+
+Accessibility behavior
+Tables remain real tables, column headers default to \`scope="col"\`, row headers default to \`scope="row"\`, and selected rows expose \`aria-selected\` so state is not color-only.
+
+Composition guidance
+Keep the foundation presentational. Use row-state styling and empty-state composition here, then layer query state, bulk actions, and feature-owned controls in application code.
+
+Known misuse patterns
+Avoid turning this into a generic data-grid abstraction or adding boolean flags for every workflow mode.
+        `.trim(),
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="overflow-x-auto rounded-[1.6rem] border border-border/80 bg-card p-3 shadow-sm">
+      <Table className="min-w-[760px]">
+        <TableCaption>
+          Dense operational table foundation with stable shared semantics.
+        </TableCaption>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Competition</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Missing items</TableHead>
+            <TableHead>Last reviewed</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableRowHeader>Autumn League A</TableRowHeader>
+            <TableCell>Ready for publication</TableCell>
+            <TableCell>0</TableCell>
+            <TableCell>Today, 14:10</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableRowHeader>Junior Open</TableRowHeader>
+            <TableCell>Review in progress</TableCell>
+            <TableCell>2 waivers</TableCell>
+            <TableCell>12 minutes ago</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableRowHeader>Club Championship</TableRowHeader>
+            <TableCell>Awaiting final seeding</TableCell>
+            <TableCell>1 category confirmation</TableCell>
+            <TableCell>32 minutes ago</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+  ),
+};
+
+export const RowStates: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use text inside the cells to explain operational meaning. Row color reinforces state but should never be the only signal.",
+      },
+    },
+  },
+  render: () => (
+    <div className="overflow-x-auto rounded-[1.6rem] border border-border/80 bg-card p-3 shadow-sm">
+      <Table className="min-w-[820px]">
+        <TableHeader>
+          <TableRow>
+            <TableHead>Registration</TableHead>
+            <TableHead>Operational state</TableHead>
+            <TableHead>Reviewer note</TableHead>
+            <TableHead>Next action</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow state="selected">
+            <TableRowHeader>Pair 04</TableRowHeader>
+            <TableCell>Selected</TableCell>
+            <TableCell>Included in the active bulk-approval set.</TableCell>
+            <TableCell>Confirm supporting documents.</TableCell>
+          </TableRow>
+          <TableRow state="warning">
+            <TableRowHeader>Pair 12</TableRowHeader>
+            <TableCell>Warning</TableCell>
+            <TableCell>Medical waiver expires before match week.</TableCell>
+            <TableCell>Request updated attachment.</TableCell>
+          </TableRow>
+          <TableRow state="invalid">
+            <TableRowHeader>Pair 18</TableRowHeader>
+            <TableCell>Invalid</TableCell>
+            <TableCell>
+              Category assignment conflicts with age bracket.
+            </TableCell>
+            <TableCell>Return to organizer for correction.</TableCell>
+          </TableRow>
+          <TableRow state="completed">
+            <TableRowHeader>Pair 21</TableRowHeader>
+            <TableCell>Completed</TableCell>
+            <TableCell>
+              Verification and payment review are both closed.
+            </TableCell>
+            <TableCell>No action required.</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+  ),
+};
+
+export const EmptyTable: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use the shared empty row for absent data, but keep retry logic, filters, and loading orchestration in feature code.",
+      },
+    },
+  },
+  render: () => (
+    <div className="overflow-x-auto rounded-[1.6rem] border border-border/80 bg-card p-3 shadow-sm">
+      <Table className="min-w-[760px]">
+        <TableHeader>
+          <TableRow>
+            <TableHead>Division</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Registrations</TableHead>
+            <TableHead>Owner</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableEmptyState
+              colSpan={4}
+              description="This empty row documents the presentational state only. Feature modules should decide whether the absence comes from filters, permissions, or not-yet-created data."
+              eyebrow="Empty table"
+              title="No divisions match the current review scope"
+            />
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary
- add a shared semantic table foundation to `packages/ui` with presentational subcomponents for headers, rows, cells, captions, and empty-table composition
- support documented row states for dense operational views: `default`, `selected`, `warning`, `invalid`, and `completed`
- add Storybook coverage and guidance for dense admin usage, row states, accessibility expectations, and misuse boundaries
- extend package exports and entrypoint coverage for the new table surface

## Scope notes
- keeps the API presentational and shared-package safe
- does not add sorting, filtering, pagination, routing, query ownership, or workflow-specific action logic
- uses real table semantics so column and row relationships remain explicit

## Validation
- `pnpm --filter @padel/ui lint`
- `pnpm --filter @padel/ui typecheck`
- `pnpm --filter @padel/ui test`
- `pnpm --filter @padel/ui storybook:build`
- pre-push checks also passed for affected workspace targets via Nx

Closes #32
