### PR TITLE
feat(api): expose authenticated competition overview query

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -8,6 +8,7 @@ import { envValidationSchema } from "./common/config/env.validation.js";
 import { AuthModule } from "./common/modules/auth/auth.module.js";
 import { CoreModule } from "./common/modules/core/core.module.js";
 import { CreateCompetitionUseCase } from "./competition/application/create-competition.use-case.js";
+import { ListCompetitionOverviewUseCase } from "./competition/application/list-competition-overview.use-case.js";
 import { CompetitionRepositoryToken } from "./competition/application/ports/competition-repository.js";
 import { CompetitionController } from "./competition/inbound/http/competition.controller.js";
 import { PrismaCompetitionRepository } from "./competition/outbound/persistence/prisma-competition.repository.js";
@@ -71,6 +72,7 @@ import { PrismaModule } from "./prisma/prisma.module.js";
   controllers: [CompetitionController],
   providers: [
     CreateCompetitionUseCase,
+    ListCompetitionOverviewUseCase,
     PrismaCompetitionRepository,
     {
       provide: CompetitionRepositoryToken,

--- a/apps/api/src/competition/application/create-competition.use-case.test.ts
+++ b/apps/api/src/competition/application/create-competition.use-case.test.ts
@@ -16,6 +16,10 @@ class FakeCompetitionRepository implements CompetitionRepository {
   }): Promise<void> {
     this.created.push(competition.toPersistence());
   }
+
+  async listOverview() {
+    return [];
+  }
 }
 
 describe("CreateCompetitionUseCase", () => {

--- a/apps/api/src/competition/application/list-competition-overview.use-case.test.ts
+++ b/apps/api/src/competition/application/list-competition-overview.use-case.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { ListCompetitionOverviewUseCase } from "./list-competition-overview.use-case.js";
+import type { CompetitionRepository } from "./ports/competition-repository.js";
+
+describe("ListCompetitionOverviewUseCase", () => {
+  it("returns the overview collection from the repository boundary", async () => {
+    const expected = [
+      {
+        id: "11111111-1111-4111-8111-111111111111",
+        title: "Operations Open",
+        format: "league" as const,
+        status: "open" as const,
+        startsAt: "2026-05-10T10:00:00.000Z",
+        endsAt: "2026-05-12T18:00:00.000Z",
+        owner: {
+          id: "owner-1",
+          name: "Ops User",
+          email: "ops@example.com",
+        },
+      },
+    ] as const;
+
+    const repository: CompetitionRepository = {
+      nextId: async () => crypto.randomUUID(),
+      create: async () => undefined,
+      listOverview: async () => expected,
+    };
+
+    const useCase = new ListCompetitionOverviewUseCase(repository);
+
+    await expect(useCase.execute()).resolves.toEqual(expected);
+  });
+});

--- a/apps/api/src/competition/application/list-competition-overview.use-case.ts
+++ b/apps/api/src/competition/application/list-competition-overview.use-case.ts
@@ -1,0 +1,19 @@
+import { Inject, Injectable } from "@nestjs/common";
+import type { CompetitionOverviewCollection } from "@padel/schemas";
+
+import {
+  type CompetitionRepository,
+  CompetitionRepositoryToken,
+} from "./ports/competition-repository.js";
+
+@Injectable()
+export class ListCompetitionOverviewUseCase {
+  constructor(
+    @Inject(CompetitionRepositoryToken)
+    private readonly competitionRepository: CompetitionRepository,
+  ) {}
+
+  async execute(): Promise<CompetitionOverviewCollection> {
+    return this.competitionRepository.listOverview();
+  }
+}

--- a/apps/api/src/competition/application/ports/competition-repository.ts
+++ b/apps/api/src/competition/application/ports/competition-repository.ts
@@ -1,3 +1,4 @@
+import type { CompetitionOverviewCollection } from "@padel/schemas";
 import type { Competition } from "../../domain/competition.js";
 
 export const CompetitionRepositoryToken = Symbol("CompetitionRepository");
@@ -5,4 +6,5 @@ export const CompetitionRepositoryToken = Symbol("CompetitionRepository");
 export interface CompetitionRepository {
   nextId(): Promise<string>;
   create(competition: Competition): Promise<void>;
+  listOverview(): Promise<CompetitionOverviewCollection>;
 }

--- a/apps/api/src/competition/inbound/http/competition.controller.integration.test.ts
+++ b/apps/api/src/competition/inbound/http/competition.controller.integration.test.ts
@@ -96,6 +96,19 @@ describe.skipIf(!canRunDatabaseTests)(
         });
     });
 
+    it("rejects unauthenticated competition overview requests", async () => {
+      await request(app.getHttpServer())
+        .get("/competitions")
+        .expect(401)
+        .expect(({ body }: { body: unknown }) => {
+          expect(body).toMatchObject({
+            statusCode: 401,
+            message: "Unauthorized",
+            path: "/competitions",
+          });
+        });
+    });
+
     it("creates a competition for the authenticated user without requiring ownerId in the request", async () => {
       const agent = request.agent(app.getHttpServer());
       const email = `competition-${randomUUID()}@example.com`;
@@ -138,6 +151,45 @@ describe.skipIf(!canRunDatabaseTests)(
         ownerId: authenticatedUserId,
         status: "draft",
       });
+    });
+
+    it("returns the authenticated competition overview with owner context", async () => {
+      const agent = request.agent(app.getHttpServer());
+      const email = `competition-overview-${randomUUID()}@example.com`;
+
+      const signUpResponse = await agent
+        .post("/auth/sign-up/email")
+        .set("origin", "http://localhost:3000")
+        .send({
+          name: "Overview User",
+          email,
+          password: "password-1234",
+        })
+        .expect(200);
+
+      const authenticatedUserId = signUpResponse.body.user.id as string;
+
+      await agent.post("/competitions").send({
+        title: "Autumn Classic",
+        format: "round-robin",
+        startsAt: "2026-05-14T10:00:00.000Z",
+        endsAt: "2026-05-16T18:00:00.000Z",
+      });
+
+      const response = await agent.get("/competitions").expect(200);
+
+      expect(response.body).toEqual([
+        expect.objectContaining({
+          title: "Autumn Classic",
+          format: "round-robin",
+          status: "draft",
+          owner: {
+            id: authenticatedUserId,
+            name: "Overview User",
+            email,
+          },
+        }),
+      ]);
     });
   },
 );

--- a/apps/api/src/competition/inbound/http/competition.controller.test.ts
+++ b/apps/api/src/competition/inbound/http/competition.controller.test.ts
@@ -8,9 +8,82 @@ import { describe, expect, it } from "vitest";
 
 import { AuthenticatedGuard } from "../../../common/modules/auth/inbound/http/authenticated.guard.js";
 import { CreateCompetitionUseCase } from "../../application/create-competition.use-case.js";
+import { ListCompetitionOverviewUseCase } from "../../application/list-competition-overview.use-case.js";
 import { CompetitionController } from "./competition.controller.js";
 
 describe("CompetitionController", () => {
+  it("lists competition overview rows through the authenticated HTTP boundary", async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [CompetitionController],
+      providers: [
+        {
+          provide: CreateCompetitionUseCase,
+          useValue: {
+            execute: async () => {
+              throw new Error("should not be called");
+            },
+          },
+        },
+        {
+          provide: ListCompetitionOverviewUseCase,
+          useValue: {
+            execute: async () => [
+              {
+                id: "11111111-1111-4111-8111-111111111111",
+                title: "Winter Open",
+                format: "elimination",
+                status: "open",
+                startsAt: "2026-05-10T10:00:00.000Z",
+                endsAt: "2026-05-12T18:00:00.000Z",
+                owner: {
+                  id: "user-1",
+                  name: "Competition User",
+                  email: "competition@example.com",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    })
+      .overrideGuard(AuthenticatedGuard)
+      .useValue({
+        canActivate(context: {
+          switchToHttp(): { getRequest(): { user?: { id: string } } };
+        }) {
+          context.switchToHttp().getRequest().user = { id: "user-1" };
+          return true;
+        },
+      })
+      .compile();
+
+    const app = moduleRef.createNestApplication(new ExpressAdapter());
+    await app.init();
+
+    await request(app.getHttpServer())
+      .get("/competitions")
+      .expect(200)
+      .expect(({ body }: { body: unknown }) => {
+        expect(body).toEqual([
+          {
+            id: "11111111-1111-4111-8111-111111111111",
+            title: "Winter Open",
+            format: "elimination",
+            status: "open",
+            startsAt: "2026-05-10T10:00:00.000Z",
+            endsAt: "2026-05-12T18:00:00.000Z",
+            owner: {
+              id: "user-1",
+              name: "Competition User",
+              email: "competition@example.com",
+            },
+          },
+        ]);
+      });
+
+    await app.close();
+  });
+
   it("creates a competition through the authenticated HTTP boundary", async () => {
     const moduleRef = await Test.createTestingModule({
       controllers: [CompetitionController],
@@ -29,6 +102,12 @@ describe("CompetitionController", () => {
               ...input,
               status: "draft",
             }),
+          },
+        },
+        {
+          provide: ListCompetitionOverviewUseCase,
+          useValue: {
+            execute: async () => [],
           },
         },
       ],
@@ -80,6 +159,14 @@ describe("CompetitionController", () => {
         {
           provide: CreateCompetitionUseCase,
           useValue: { execute },
+        },
+        {
+          provide: ListCompetitionOverviewUseCase,
+          useValue: {
+            execute: async () => {
+              throw new Error("should not be called");
+            },
+          },
         },
       ],
     })

--- a/apps/api/src/competition/inbound/http/competition.controller.ts
+++ b/apps/api/src/competition/inbound/http/competition.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Get,
   HttpCode,
   HttpStatus,
   Inject,
@@ -8,6 +9,7 @@ import {
   UseGuards,
 } from "@nestjs/common";
 import {
+  competitionOverviewCollectionSchema,
   createCompetitionRequestSchema,
   createCompetitionResponseSchema,
 } from "@padel/schemas";
@@ -16,6 +18,7 @@ import type { AuthenticatedUser } from "../../../common/modules/auth/application
 import { AuthenticatedGuard } from "../../../common/modules/auth/inbound/http/authenticated.guard.js";
 import { CurrentUser } from "../../../common/modules/auth/inbound/http/current-user.decorator.js";
 import { CreateCompetitionUseCase } from "../../application/create-competition.use-case.js";
+import { ListCompetitionOverviewUseCase } from "../../application/list-competition-overview.use-case.js";
 import { mapCreateCompetitionRequestToCommand } from "./create-competition-request.mapper.js";
 
 @Controller("competitions")
@@ -23,7 +26,17 @@ export class CompetitionController {
   constructor(
     @Inject(CreateCompetitionUseCase)
     private readonly createCompetitionUseCase: CreateCompetitionUseCase,
+    @Inject(ListCompetitionOverviewUseCase)
+    private readonly listCompetitionOverviewUseCase: ListCompetitionOverviewUseCase,
   ) {}
+
+  @Get()
+  @UseGuards(AuthenticatedGuard)
+  async listCompetitionOverview() {
+    const response = await this.listCompetitionOverviewUseCase.execute();
+
+    return competitionOverviewCollectionSchema.parse(response);
+  }
 
   @Post()
   @UseGuards(AuthenticatedGuard)

--- a/apps/api/src/competition/outbound/persistence/competition-overview.mapper.test.ts
+++ b/apps/api/src/competition/outbound/persistence/competition-overview.mapper.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { mapCompetitionOverviewRow } from "./competition-overview.mapper.js";
+
+describe("mapCompetitionOverviewRow", () => {
+  it("maps persistence rows into the published overview contract", () => {
+    expect(
+      mapCompetitionOverviewRow({
+        id: "11111111-1111-4111-8111-111111111111",
+        title: "Regional Open",
+        format: "round_robin",
+        status: "open",
+        startsAt: new Date("2026-05-10T10:00:00.000Z"),
+        endsAt: new Date("2026-05-12T18:00:00.000Z"),
+        owner: {
+          id: "owner-1",
+          name: "Operations User",
+          email: "ops@example.com",
+        },
+      }),
+    ).toEqual({
+      id: "11111111-1111-4111-8111-111111111111",
+      title: "Regional Open",
+      format: "round-robin",
+      status: "open",
+      startsAt: "2026-05-10T10:00:00.000Z",
+      endsAt: "2026-05-12T18:00:00.000Z",
+      owner: {
+        id: "owner-1",
+        name: "Operations User",
+        email: "ops@example.com",
+      },
+    });
+  });
+});

--- a/apps/api/src/competition/outbound/persistence/competition-overview.mapper.ts
+++ b/apps/api/src/competition/outbound/persistence/competition-overview.mapper.ts
@@ -1,0 +1,33 @@
+import type { CompetitionOverviewItem } from "@padel/schemas";
+
+interface CompetitionOverviewRow {
+  id: string;
+  title: string;
+  format: "elimination" | "round_robin" | "league";
+  status: "draft" | "open" | "closed";
+  startsAt: Date;
+  endsAt: Date;
+  owner: {
+    id: string;
+    name: string;
+    email: string;
+  };
+}
+
+export function mapCompetitionOverviewRow(
+  row: CompetitionOverviewRow,
+): CompetitionOverviewItem {
+  return {
+    id: row.id,
+    title: row.title,
+    format: row.format === "round_robin" ? "round-robin" : row.format,
+    status: row.status,
+    startsAt: row.startsAt.toISOString(),
+    endsAt: row.endsAt.toISOString(),
+    owner: {
+      id: row.owner.id,
+      name: row.owner.name,
+      email: row.owner.email,
+    },
+  };
+}

--- a/apps/api/src/competition/outbound/persistence/prisma-competition.repository.ts
+++ b/apps/api/src/competition/outbound/persistence/prisma-competition.repository.ts
@@ -1,8 +1,10 @@
 import { Inject, Injectable } from "@nestjs/common";
+import { competitionOverviewCollectionSchema } from "@padel/schemas";
 
 import { PrismaService } from "../../../prisma/prisma.service.js";
 import type { CompetitionRepository } from "../../application/ports/competition-repository.js";
 import type { Competition } from "../../domain/competition.js";
+import { mapCompetitionOverviewRow } from "./competition-overview.mapper.js";
 
 @Injectable()
 export class PrismaCompetitionRepository implements CompetitionRepository {
@@ -26,5 +28,48 @@ export class PrismaCompetitionRepository implements CompetitionRepository {
         status: row.status,
       },
     });
+  }
+
+  async listOverview() {
+    const competitions = await this.prisma.competition.findMany({
+      orderBy: [{ startsAt: "asc" }, { createdAt: "asc" }],
+    });
+
+    const ownerIds = [...new Set(competitions.map(({ ownerId }) => ownerId))];
+    const owners = await this.prisma.user.findMany({
+      where: {
+        id: {
+          in: ownerIds,
+        },
+      },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+      },
+    });
+    const ownersById = new Map(owners.map((owner) => [owner.id, owner]));
+
+    return competitionOverviewCollectionSchema.parse(
+      competitions.map((competition) => {
+        const owner = ownersById.get(competition.ownerId);
+
+        if (!owner) {
+          throw new Error(
+            `Competition owner context is missing for ${competition.id}.`,
+          );
+        }
+
+        return mapCompetitionOverviewRow({
+          id: competition.id,
+          title: competition.title,
+          format: competition.format,
+          status: competition.status,
+          startsAt: competition.startsAt,
+          endsAt: competition.endsAt,
+          owner,
+        });
+      }),
+    );
   }
 }

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -32,10 +32,43 @@ export const createCompetitionResponseSchema = z.object({
   status: z.literal("draft"),
 });
 
+export const competitionOverviewOwnerSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    email: z.email(),
+  })
+  .strict();
+
+export const competitionOverviewItemSchema = z
+  .object({
+    id: z.string().uuid(),
+    title: z.string(),
+    format: z.enum(["elimination", "round-robin", "league"]),
+    status: z.enum(["draft", "open", "closed"]),
+    startsAt: z.iso.datetime(),
+    endsAt: z.iso.datetime(),
+    owner: competitionOverviewOwnerSchema,
+  })
+  .strict();
+
+export const competitionOverviewCollectionSchema = z
+  .array(competitionOverviewItemSchema)
+  .readonly();
+
 export type CreateCompetitionRequest = z.infer<
   typeof createCompetitionRequestSchema
 >;
 export type CreateCompetitionResponse = z.infer<
   typeof createCompetitionResponseSchema
+>;
+export type CompetitionOverviewOwner = z.infer<
+  typeof competitionOverviewOwnerSchema
+>;
+export type CompetitionOverviewItem = z.infer<
+  typeof competitionOverviewItemSchema
+>;
+export type CompetitionOverviewCollection = z.infer<
+  typeof competitionOverviewCollectionSchema
 >;
 export type SharedPingContract = z.infer<typeof sharedPingContract>;

--- a/packages/schemas/test/index.test.ts
+++ b/packages/schemas/test/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  competitionOverviewCollectionSchema,
   createCompetitionRequestSchema,
   createCompetitionResponseSchema,
 } from "../src/index.js";
@@ -43,6 +44,41 @@ describe("competition schemas", () => {
         ownerId: "owner-1",
         status: "open",
       }),
+    ).toThrow();
+  });
+
+  it("parses a valid competition overview collection", () => {
+    expect(
+      competitionOverviewCollectionSchema.parse([
+        {
+          id: crypto.randomUUID(),
+          title: "Regional Open",
+          format: "round-robin",
+          status: "open",
+          startsAt: "2026-05-10T10:00:00.000Z",
+          endsAt: "2026-05-12T18:00:00.000Z",
+          owner: {
+            id: "owner-1",
+            name: "Operations User",
+            email: "ops@example.com",
+          },
+        },
+      ]),
+    ).toHaveLength(1);
+  });
+
+  it("rejects a competition overview item without owner context", () => {
+    expect(() =>
+      competitionOverviewCollectionSchema.parse([
+        {
+          id: crypto.randomUUID(),
+          title: "Regional Open",
+          format: "round-robin",
+          status: "open",
+          startsAt: "2026-05-10T10:00:00.000Z",
+          endsAt: "2026-05-12T18:00:00.000Z",
+        },
+      ]),
     ).toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- add an authenticated `GET /competitions` overview endpoint for operational users
- publish the competition overview response contract from `@padel/schemas`
- keep overview shaping in the Prisma adapter/read-model boundary with unit and integration coverage

## Testing
- `pnpm --filter @padel/schemas build`
- `pnpm --filter @padel/schemas lint`
- `pnpm --filter @padel/schemas test`
- `pnpm --filter @padel/api lint`
- `pnpm --filter @padel/api typecheck`
- `pnpm --filter @padel/api test`
- `git push -u origin codex/issue-38-competition-overview-query` (pre-push ran Nx affected lint/typecheck/test/build plus boundaries)

Closes #38