### PR TITLE
feat: add competition operations overview scaffold

### DIFF
--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,6 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "baseUrl": "../..",
+    "paths": {
+      "@padel/schemas": ["packages/schemas/dist/index.d.ts"]
+    },
     "rootDir": "./src"
   },
   "include": ["src/**/*.ts"],

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>Padel Operations</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "dev": "vite",
     "lint": "biome check src package.json tsconfig.json tsconfig.build.json",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,10 +13,13 @@
     "@padel/api-client": "workspace:*",
     "@padel/schemas": "workspace:*",
     "@padel/ui": "workspace:*",
+    "@tanstack/react-query": "^5.100.7",
+    "@tanstack/react-router": "^1.169.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.0",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2"
   },

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -1,30 +1,16 @@
-import { sampleContractSummary } from "@padel/api-client";
-import { sharedPingContract } from "@padel/schemas";
-import { Button } from "@padel/ui";
+import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { RouterProvider } from "@tanstack/react-router";
+import type { createWebRouter } from "./router.js";
 
-export function App() {
+interface AppProps {
+  queryClient: QueryClient;
+  router: ReturnType<typeof createWebRouter>;
+}
+
+export function App({ queryClient, router }: AppProps) {
   return (
-    <main className="min-h-screen bg-background px-6 py-16 text-foreground">
-      <div className="mx-auto flex max-w-3xl flex-col gap-6 rounded-3xl border border-border bg-white/80 p-8 shadow-sm">
-        <div className="flex flex-col gap-3">
-          <p className="text-sm font-medium uppercase tracking-[0.2em] text-muted-foreground">
-            Padel monorepo foundation
-          </p>
-          <h1 className="text-4xl font-semibold tracking-tight">
-            Shared UI foundation is now wired for reusable primitives.
-          </h1>
-          <p className="max-w-2xl text-base leading-7 text-muted-foreground">
-            {sampleContractSummary()} Shared schema status:{" "}
-            {sharedPingContract.shape.status.value}
-          </p>
-        </div>
-
-        <div className="flex flex-wrap gap-3">
-          <Button>Register players</Button>
-          <Button variant="secondary">Review submissions</Button>
-          <Button variant="outline">Plan Storybook rollout</Button>
-        </div>
-      </div>
-    </main>
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
   );
 }

--- a/apps/web/src/features/competition-operations/competition-operations-screen.tsx
+++ b/apps/web/src/features/competition-operations/competition-operations-screen.tsx
@@ -1,0 +1,148 @@
+import {
+  Button,
+  EmptyState,
+  EmptyStateDescription,
+  EmptyStateEyebrow,
+  EmptyStateTitle,
+  InlineAlert,
+  InlineAlertDescription,
+  InlineAlertTitle,
+  InlineMetadataList,
+  KeyValueSummaryBlock,
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@padel/ui";
+import { Link } from "@tanstack/react-router";
+import type { CompetitionOverviewPageViewModel } from "./competition-overview-view-model.js";
+
+interface CompetitionOperationsScreenProps {
+  model: CompetitionOverviewPageViewModel;
+}
+
+export function CompetitionOperationsScreen({
+  model,
+}: CompetitionOperationsScreenProps) {
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_hsla(var(--accent)/0.75),_transparent_38%),linear-gradient(180deg,_hsl(var(--background)),_hsl(var(--secondary)/0.52))] px-4 py-8 text-foreground sm:px-6 lg:px-10">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6">
+        <section className="overflow-hidden rounded-[2rem] border border-border/70 bg-[linear-gradient(135deg,_rgba(255,255,255,0.9),_rgba(231,242,236,0.95))] p-6 shadow-[0_20px_80px_rgba(33,72,53,0.08)] sm:p-8">
+          <div className="grid gap-6 lg:grid-cols-[1.3fr_0.7fr]">
+            <div className="space-y-4">
+              <p className="font-mono text-xs uppercase tracking-[0.34em] text-muted-foreground">
+                Authenticated operations
+              </p>
+              <div className="space-y-3">
+                <h1 className="max-w-3xl font-serif text-4xl leading-tight tracking-tight sm:text-5xl">
+                  Competition operations overview with route-owned loading and
+                  shared admin display primitives.
+                </h1>
+                <p className="max-w-2xl text-sm leading-7 text-muted-foreground sm:text-base">
+                  This first route scaffold keeps routing, query orchestration,
+                  and DTO mapping in <code>apps/web</code> while the table,
+                  summary, and feedback surfaces stay reusable in{" "}
+                  <code>packages/ui</code>.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-3">
+                <Button asChild size="lg">
+                  <Link to="/competitions/operations">
+                    Refresh operations view
+                  </Link>
+                </Button>
+                <Button asChild size="lg" variant="outline">
+                  <Link to="/sign-in">View sign-in boundary</Link>
+                </Button>
+              </div>
+            </div>
+
+            <KeyValueSummaryBlock
+              columns={1}
+              description="Operational trust comes from making missing data and blocked workflows visible before detail editing starts."
+              heading="Snapshot"
+              items={model.summaryItems}
+            />
+          </div>
+        </section>
+
+        {model.attentionMessage ? (
+          <InlineAlert variant="warning">
+            <InlineAlertTitle variant="warning">
+              Route-critical issues surfaced at the overview boundary
+            </InlineAlertTitle>
+            <InlineAlertDescription>
+              {model.attentionMessage}
+            </InlineAlertDescription>
+          </InlineAlert>
+        ) : null}
+
+        {model.rows.length === 0 ? (
+          <EmptyState className="max-w-none bg-white/85" variant="info">
+            <EmptyStateEyebrow>Competition operations</EmptyStateEyebrow>
+            <EmptyStateTitle>
+              No competitions need operational review yet.
+            </EmptyStateTitle>
+            <EmptyStateDescription>
+              Once authenticated competition data is available, this route will
+              promote the highest-risk items here without turning the shared UI
+              package into a workflow-specific screen.
+            </EmptyStateDescription>
+          </EmptyState>
+        ) : (
+          <TableContainer>
+            <Table>
+              <TableHeader>
+                <tr>
+                  <TableHead scope="col">Competition</TableHead>
+                  <TableHead scope="col">Schedule</TableHead>
+                  <TableHead scope="col">Operations</TableHead>
+                  <TableHead scope="col">Next action</TableHead>
+                </tr>
+              </TableHeader>
+              <TableBody>
+                {model.rows.map((row) => (
+                  <TableRow key={row.id} state={row.rowState}>
+                    <TableCell className="space-y-3">
+                      <div className="space-y-1">
+                        <p className="font-serif text-xl leading-none tracking-tight">
+                          {row.title}
+                        </p>
+                        <p className="font-mono text-[0.72rem] uppercase tracking-[0.24em] text-muted-foreground">
+                          {row.statusLabel}
+                        </p>
+                      </div>
+                      <InlineMetadataList
+                        className="border-border/60 bg-background/70"
+                        items={row.metadataItems}
+                      />
+                    </TableCell>
+                    <TableCell className="font-medium">
+                      {row.scheduleLabel}
+                    </TableCell>
+                    <TableCell>{row.operationsSummary}</TableCell>
+                    <TableCell className="font-medium">
+                      {row.nextActionLabel}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+              <TableCaption>
+                Shared UI owns the table foundation. App space owns route data,
+                risk mapping, and future drill-in actions.
+              </TableCaption>
+            </Table>
+          </TableContainer>
+        )}
+
+        <p className="px-1 font-mono text-xs uppercase tracking-[0.24em] text-muted-foreground">
+          Overview generated {model.generatedAtLabel}
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/features/competition-operations/competition-overview-fixtures.ts
+++ b/apps/web/src/features/competition-operations/competition-overview-fixtures.ts
@@ -42,4 +42,5 @@ export const competitionOverviewFixture: CompetitionOverviewCollection = [
   },
 ];
 
-export const emptyCompetitionOverviewFixture: CompetitionOverviewCollection = [];
+export const emptyCompetitionOverviewFixture: CompetitionOverviewCollection =
+  [];

--- a/apps/web/src/features/competition-operations/competition-overview-fixtures.ts
+++ b/apps/web/src/features/competition-operations/competition-overview-fixtures.ts
@@ -1,0 +1,45 @@
+import type { CompetitionOverviewCollection } from "@padel/schemas";
+
+export const competitionOverviewFixture: CompetitionOverviewCollection = [
+  {
+    id: "fa222204-b855-4fb0-b507-e169249e588e",
+    title: "North Circuit Masters",
+    format: "round-robin",
+    status: "open",
+    startsAt: "2026-05-03T12:00:00.000Z",
+    endsAt: "2026-05-05T21:00:00.000Z",
+    owner: {
+      id: "44e7eb17-a42b-4de8-bf34-2f8d78680d39",
+      name: "Lucia Perez",
+      email: "lucia@example.com",
+    },
+  },
+  {
+    id: "d3f0afb5-3206-4f8d-bf78-40adfdfcbb13",
+    title: "Club League Apertura",
+    format: "league",
+    status: "draft",
+    startsAt: "2026-05-08T15:00:00.000Z",
+    endsAt: "2026-05-20T22:00:00.000Z",
+    owner: {
+      id: "fae8da22-b34f-4820-bab5-cf4a2e474d68",
+      name: "Mateo Sosa",
+      email: "mateo@example.com",
+    },
+  },
+  {
+    id: "8e948e4d-a326-42dd-89f9-e4afbfd84992",
+    title: "Saturday Social Draw",
+    format: "elimination",
+    status: "closed",
+    startsAt: "2026-05-10T16:00:00.000Z",
+    endsAt: "2026-05-10T23:00:00.000Z",
+    owner: {
+      id: "bd1a2c2d-f4aa-4c9b-b3fe-4a35ea8cfe6f",
+      name: "Ariana Lopez",
+      email: "ariana@example.com",
+    },
+  },
+];
+
+export const emptyCompetitionOverviewFixture: CompetitionOverviewCollection = [];

--- a/apps/web/src/features/competition-operations/competition-overview-query.ts
+++ b/apps/web/src/features/competition-operations/competition-overview-query.ts
@@ -1,0 +1,9 @@
+import type { PadelApiClient } from "@padel/api-client";
+import { queryOptions } from "@tanstack/react-query";
+
+export function competitionOverviewQueryOptions(apiClient: PadelApiClient) {
+  return queryOptions({
+    queryKey: ["competitions", "overview"],
+    queryFn: ({ signal }) => apiClient.getCompetitionOverview({ signal }),
+  });
+}

--- a/apps/web/src/features/competition-operations/competition-overview-view-model.ts
+++ b/apps/web/src/features/competition-operations/competition-overview-view-model.ts
@@ -1,0 +1,166 @@
+import type {
+  CompetitionOverviewCollection,
+  CompetitionOverviewItem,
+} from "@padel/schemas";
+import type {
+  InlineMetadataItem,
+  KeyValueSummaryItem,
+  TableRowState,
+} from "@padel/ui";
+
+const dateTimeFormatter = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeStyle: "short",
+  timeZone: "UTC",
+});
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  day: "numeric",
+  month: "short",
+  timeZone: "UTC",
+});
+
+const formatLabelMap: Record<CompetitionOverviewItem["format"], string> = {
+  elimination: "Elimination",
+  league: "League",
+  "round-robin": "Round robin",
+};
+
+const statusLabelMap: Record<CompetitionOverviewItem["status"], string> = {
+  closed: "Closed",
+  draft: "Draft",
+  open: "Open",
+};
+
+export interface CompetitionOverviewRowViewModel {
+  id: string;
+  metadataItems: InlineMetadataItem[];
+  nextActionLabel: string;
+  operationsSummary: string;
+  rowState: TableRowState;
+  scheduleLabel: string;
+  statusLabel: string;
+  title: string;
+}
+
+export interface CompetitionOverviewPageViewModel {
+  attentionMessage: string | null;
+  generatedAtLabel: string;
+  rows: CompetitionOverviewRowViewModel[];
+  summaryItems: KeyValueSummaryItem[];
+}
+
+function formatScheduleWindow(startsAt: string, endsAt: string) {
+  return `${dateFormatter.format(new Date(startsAt))} to ${dateFormatter.format(new Date(endsAt))}`;
+}
+
+function summarizeOperations(item: CompetitionOverviewItem) {
+  return `Owned by ${item.owner.name} • ${statusLabelMap[item.status]} competition`;
+}
+
+function selectNextActionLabel(item: CompetitionOverviewItem) {
+  if (item.status === "draft") {
+    return "Complete setup before opening registrations";
+  }
+
+  if (item.status === "open") {
+    return "Review registrations and keep operations moving";
+  }
+
+  return "Inspect final competition record";
+}
+
+function selectRowState(item: CompetitionOverviewItem): TableRowState {
+  if (item.status === "draft") {
+    return "warning";
+  }
+
+  if (item.status === "open") {
+    return "selected";
+  }
+
+  return "completed";
+}
+
+export function mapCompetitionOverviewToPageModel(
+  response: CompetitionOverviewCollection,
+): CompetitionOverviewPageViewModel {
+  const totals = response.reduce(
+    (accumulator, item: CompetitionOverviewItem) => ({
+      closed: accumulator.closed + Number(item.status === "closed"),
+      draft: accumulator.draft + Number(item.status === "draft"),
+      open: accumulator.open + Number(item.status === "open"),
+    }),
+    {
+      closed: 0,
+      draft: 0,
+      open: 0,
+    },
+  );
+
+  const attentionMessage =
+    totals.draft > 0
+      ? `${totals.draft} competitions are still in draft and need setup before operators can rely on them.`
+      : totals.open > 0
+        ? `${totals.open} active competition overviews are open for daily operations follow-up.`
+        : null;
+
+  return {
+    attentionMessage,
+    generatedAtLabel: "Live collection response",
+    rows: response.map((item: CompetitionOverviewItem) => ({
+      id: item.id,
+      metadataItems: [
+        {
+          label: "Format",
+          value: formatLabelMap[item.format],
+        },
+        {
+          label: "Status",
+          tone: item.status === "draft" ? "warning" : "default",
+          value: statusLabelMap[item.status],
+        },
+        {
+          label: "Owner",
+          value: item.owner.name,
+        },
+        {
+          label: "Contact",
+          value: item.owner.email,
+        },
+      ],
+      nextActionLabel: selectNextActionLabel(item),
+      operationsSummary: summarizeOperations(item),
+      rowState: selectRowState(item),
+      scheduleLabel: formatScheduleWindow(item.startsAt, item.endsAt),
+      statusLabel: statusLabelMap[item.status],
+      title: item.title,
+    })),
+    summaryItems: [
+      {
+        label: "Competitions in view",
+        value: String(response.length),
+      },
+      {
+        label: "Draft",
+        tone: totals.draft > 0 ? "warning" : "default",
+        value: String(totals.draft),
+      },
+      {
+        label: "Open",
+        tone: totals.open > 0 ? "warning" : "default",
+        value: String(totals.open),
+      },
+      {
+        label: "Closed",
+        tone: totals.closed > 0 ? "success" : "default",
+        value: String(totals.closed),
+      },
+      {
+        label: "Transport shape",
+        tone: "muted",
+        value: "Competition overview collection",
+      },
+    ],
+  };
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,16 +1,43 @@
+import { createApiClient } from "@padel/api-client";
+import { QueryClient } from "@tanstack/react-query";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "@padel/ui/styles.css";
 
 import { App } from "./app.js";
+import { createWebRouter } from "./router.js";
+import { createScaffoldApiFetch } from "./scaffold-api-fetch.js";
 
 const container = document.getElementById("root");
 
 if (container) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: 30_000,
+      },
+    },
+  });
+
+  const apiClient = createApiClient({
+    fetch: createScaffoldApiFetch(),
+  });
+
+  const router = createWebRouter({
+    apiClient,
+    auth: {
+      isAuthenticated: true,
+      roleLabel: "Competition operations",
+      userName: "Operations desk",
+    },
+    queryClient,
+  });
+
   const root = createRoot(container);
   root.render(
     <StrictMode>
-      <App />
+      <App queryClient={queryClient} router={router} />
     </StrictMode>,
   );
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,0 +1,190 @@
+import type { PadelApiClient } from "@padel/api-client";
+import {
+  Button,
+  EmptyState,
+  EmptyStateDescription,
+  EmptyStateEyebrow,
+  EmptyStateTitle,
+  InlineAlert,
+  InlineAlertDescription,
+  InlineAlertTitle,
+  Skeleton,
+} from "@padel/ui";
+import { type QueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import {
+  type ErrorComponentProps,
+  Link,
+  Outlet,
+  type RouterHistory,
+  createBrowserHistory,
+  createMemoryHistory,
+  createRootRouteWithContext,
+  createRoute,
+  createRouter,
+  redirect,
+} from "@tanstack/react-router";
+import { CompetitionOperationsScreen } from "./features/competition-operations/competition-operations-screen.js";
+import { competitionOverviewQueryOptions } from "./features/competition-operations/competition-overview-query.js";
+import { mapCompetitionOverviewToPageModel } from "./features/competition-operations/competition-overview-view-model.js";
+
+export interface WebAuthContext {
+  isAuthenticated: boolean;
+  roleLabel: string;
+  userName: string;
+}
+
+export interface WebRouterContext {
+  apiClient: PadelApiClient;
+  auth: WebAuthContext;
+  queryClient: QueryClient;
+}
+
+const rootRoute = createRootRouteWithContext<WebRouterContext>()({
+  component: RootLayout,
+});
+
+const signInRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/sign-in",
+  component: SignInScreen,
+});
+
+const authenticatedRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  id: "authenticated",
+  beforeLoad: ({ context, location }) => {
+    if (!context.auth.isAuthenticated) {
+      throw redirect({
+        search: {
+          redirect: location.href,
+        },
+        to: "/sign-in",
+      });
+    }
+  },
+  component: AuthenticatedLayout,
+});
+
+const competitionOperationsRoute = createRoute({
+  getParentRoute: () => authenticatedRoute,
+  path: "/competitions/operations",
+  loader: ({ context }) =>
+    context.queryClient.ensureQueryData(
+      competitionOverviewQueryOptions(context.apiClient),
+    ),
+  pendingComponent: CompetitionOperationsPending,
+  pendingMs: 0,
+  errorComponent: CompetitionOperationsError,
+  component: CompetitionOperationsRouteScreen,
+});
+
+const routeTree = rootRoute.addChildren([
+  signInRoute,
+  authenticatedRoute.addChildren([competitionOperationsRoute]),
+]);
+
+function RootLayout() {
+  return <Outlet />;
+}
+
+function AuthenticatedLayout() {
+  return <Outlet />;
+}
+
+function SignInScreen() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-[linear-gradient(180deg,_hsl(var(--background)),_hsl(var(--secondary)/0.44))] px-6 py-12">
+      <EmptyState className="max-w-2xl bg-white/90" variant="info">
+        <EmptyStateEyebrow>Authentication scaffold</EmptyStateEyebrow>
+        <EmptyStateTitle>
+          Sign-in lives outside the operations route group.
+        </EmptyStateTitle>
+        <EmptyStateDescription>
+          This route exists so the first competition operations screen can sit
+          behind an explicit authenticated boundary now, while the real auth UI
+          lands in a later ticket.
+        </EmptyStateDescription>
+        <div className="pt-1">
+          <Button asChild>
+            <Link to="/competitions/operations">
+              Return to scaffolded overview
+            </Link>
+          </Button>
+        </div>
+      </EmptyState>
+    </main>
+  );
+}
+
+function CompetitionOperationsRouteScreen() {
+  const { apiClient } = competitionOperationsRoute.useRouteContext();
+  const { data } = useSuspenseQuery(competitionOverviewQueryOptions(apiClient));
+
+  return (
+    <CompetitionOperationsScreen
+      model={mapCompetitionOverviewToPageModel(data)}
+    />
+  );
+}
+
+function CompetitionOperationsPending() {
+  return (
+    <main className="min-h-screen bg-[linear-gradient(180deg,_hsl(var(--background)),_hsl(var(--secondary)/0.52))] px-4 py-8 sm:px-6 lg:px-10">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6">
+        <div className="rounded-[2rem] border border-border/70 bg-white/80 p-6 shadow-sm sm:p-8">
+          <div className="space-y-4">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-14 w-full max-w-3xl" />
+            <Skeleton className="h-6 w-full max-w-2xl" />
+          </div>
+        </div>
+        <Skeleton className="h-40 w-full rounded-[1.5rem]" />
+        <Skeleton className="h-80 w-full rounded-[1.5rem]" />
+      </div>
+    </main>
+  );
+}
+
+function CompetitionOperationsError({ error }: ErrorComponentProps) {
+  const message =
+    error instanceof Error
+      ? error.message
+      : "Unable to load competition overview.";
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-[linear-gradient(180deg,_hsl(var(--background)),_hsl(var(--secondary)/0.52))] px-6 py-12">
+      <InlineAlert className="max-w-2xl bg-white/90" variant="blocked">
+        <InlineAlertTitle variant="blocked">
+          Competition overview could not be loaded
+        </InlineAlertTitle>
+        <InlineAlertDescription>{message}</InlineAlertDescription>
+      </InlineAlert>
+    </main>
+  );
+}
+
+export function createWebRouter({
+  apiClient,
+  auth,
+  history = createBrowserHistory(),
+  queryClient,
+}: WebRouterContext & {
+  history?: RouterHistory;
+}) {
+  return createRouter({
+    context: {
+      apiClient,
+      auth,
+      queryClient,
+    },
+    history,
+    routeTree,
+    scrollRestoration: true,
+  });
+}
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: ReturnType<typeof createWebRouter>;
+  }
+}

--- a/apps/web/src/scaffold-api-fetch.ts
+++ b/apps/web/src/scaffold-api-fetch.ts
@@ -1,0 +1,30 @@
+import { competitionOverviewPath } from "@padel/api-client";
+import { competitionOverviewFixture } from "./features/competition-operations/competition-overview-fixtures.js";
+
+const fixtureLatencyMs = 120;
+
+function delay(durationMs: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, durationMs);
+  });
+}
+
+export function createScaffoldApiFetch(): typeof globalThis.fetch {
+  return async (input, init) => {
+    const request = new Request(input, init);
+    const requestUrl = new URL(request.url, "https://padel.local");
+
+    if (requestUrl.pathname.endsWith(competitionOverviewPath)) {
+      await delay(fixtureLatencyMs);
+
+      return new Response(JSON.stringify(competitionOverviewFixture), {
+        headers: {
+          "content-type": "application/json",
+        },
+        status: 200,
+      });
+    }
+
+    return globalThis.fetch(request);
+  };
+}

--- a/apps/web/test/router.test.tsx
+++ b/apps/web/test/router.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+
+import { createApiClient } from "@padel/api-client";
+import { QueryClient } from "@tanstack/react-query";
+import { createMemoryHistory } from "@tanstack/react-router";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { App } from "../src/app.js";
+import {
+  competitionOverviewFixture,
+  emptyCompetitionOverviewFixture,
+} from "../src/features/competition-operations/competition-overview-fixtures.js";
+import { createWebRouter } from "../src/router.js";
+
+(window as Window & { scrollTo: () => void }).scrollTo = () => {};
+
+function createTestRouter(fetchImplementation: typeof globalThis.fetch) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  const apiClient = createApiClient({
+    fetch: fetchImplementation,
+  });
+
+  const router = createWebRouter({
+    apiClient,
+    auth: {
+      isAuthenticated: true,
+      roleLabel: "Competition operations",
+      userName: "Operations desk",
+    },
+    history: createMemoryHistory({
+      initialEntries: ["/competitions/operations"],
+    }),
+    queryClient,
+  });
+
+  return {
+    queryClient,
+    router,
+  };
+}
+
+describe("competition operations route", () => {
+  it("renders the loading state while the route-critical query is pending", async () => {
+    const { queryClient, router } = createTestRouter(
+      () =>
+        new Promise<Response>(() => {
+          // Intentionally unresolved to keep the route in its pending state.
+        }),
+    );
+
+    render(<App queryClient={queryClient} router={router} />);
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-slot="skeleton"]')).not.toBeNull();
+    });
+  });
+
+  it("renders the empty state when the overview query returns no competitions", async () => {
+    const { queryClient, router } = createTestRouter(async () =>
+      new Response(JSON.stringify(emptyCompetitionOverviewFixture), {
+        headers: {
+          "content-type": "application/json",
+        },
+        status: 200,
+      }),
+    );
+
+    render(<App queryClient={queryClient} router={router} />);
+
+    expect(
+      await screen.findByText("No competitions need operational review yet."),
+    ).toBeTruthy();
+  });
+
+  it("renders the blocked error state when the query fails", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const { queryClient, router } = createTestRouter(async () =>
+      new Response(JSON.stringify({ message: "Backend unavailable" }), {
+        headers: {
+          "content-type": "application/json",
+        },
+        status: 503,
+      }),
+    );
+
+    render(<App queryClient={queryClient} router={router} />);
+
+    expect(
+      await screen.findByText("Competition overview could not be loaded"),
+    ).toBeTruthy();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("renders the populated operational table with shared UI primitives", async () => {
+    const { queryClient, router } = createTestRouter(async () =>
+      new Response(JSON.stringify(competitionOverviewFixture), {
+        headers: {
+          "content-type": "application/json",
+        },
+        status: 200,
+      }),
+    );
+
+    render(<App queryClient={queryClient} router={router} />);
+
+    expect(await screen.findByText("North Circuit Masters")).toBeTruthy();
+    expect(
+      screen.getByText("Review registrations and keep operations moving"),
+    ).toBeTruthy();
+    expect(document.querySelector('[data-slot="table"]')).not.toBeNull();
+    expect(document.querySelector('[data-slot="inline-alert"]')).not.toBeNull();
+  });
+});

--- a/apps/web/test/router.test.tsx
+++ b/apps/web/test/router.test.tsx
@@ -63,13 +63,14 @@ describe("competition operations route", () => {
   });
 
   it("renders the empty state when the overview query returns no competitions", async () => {
-    const { queryClient, router } = createTestRouter(async () =>
-      new Response(JSON.stringify(emptyCompetitionOverviewFixture), {
-        headers: {
-          "content-type": "application/json",
-        },
-        status: 200,
-      }),
+    const { queryClient, router } = createTestRouter(
+      async () =>
+        new Response(JSON.stringify(emptyCompetitionOverviewFixture), {
+          headers: {
+            "content-type": "application/json",
+          },
+          status: 200,
+        }),
     );
 
     render(<App queryClient={queryClient} router={router} />);
@@ -84,13 +85,14 @@ describe("competition operations route", () => {
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
 
-    const { queryClient, router } = createTestRouter(async () =>
-      new Response(JSON.stringify({ message: "Backend unavailable" }), {
-        headers: {
-          "content-type": "application/json",
-        },
-        status: 503,
-      }),
+    const { queryClient, router } = createTestRouter(
+      async () =>
+        new Response(JSON.stringify({ message: "Backend unavailable" }), {
+          headers: {
+            "content-type": "application/json",
+          },
+          status: 503,
+        }),
     );
 
     render(<App queryClient={queryClient} router={router} />);
@@ -103,13 +105,14 @@ describe("competition operations route", () => {
   });
 
   it("renders the populated operational table with shared UI primitives", async () => {
-    const { queryClient, router } = createTestRouter(async () =>
-      new Response(JSON.stringify(competitionOverviewFixture), {
-        headers: {
-          "content-type": "application/json",
-        },
-        status: 200,
-      }),
+    const { queryClient, router } = createTestRouter(
+      async () =>
+        new Response(JSON.stringify(competitionOverviewFixture), {
+          headers: {
+            "content-type": "application/json",
+          },
+          status: 200,
+        }),
     );
 
     render(<App queryClient={queryClient} router={router} />);

--- a/apps/web/tsconfig.build.json
+++ b/apps/web/tsconfig.build.json
@@ -1,6 +1,13 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "baseUrl": "../..",
+    "paths": {
+      "@padel/api-client": ["packages/api-client/dist/index.d.ts"],
+      "@padel/schemas": ["packages/schemas/dist/index.d.ts"],
+      "@padel/ui": ["packages/ui/dist/index.d.ts"],
+      "@padel/ui/styles.css": ["packages/ui/dist/styles.css"]
+    },
     "rootDir": "./src"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,7 +1,93 @@
-import { sharedPingContract } from "@padel/schemas";
+import {
+  competitionOverviewCollectionSchema,
+  type CompetitionOverviewCollection,
+  sharedPingContract,
+} from "@padel/schemas";
+
+export const competitionOverviewPath = "/competitions";
 
 export function sampleContractSummary() {
   const parsed = sharedPingContract.parse({ status: "ok", version: "0.0.0" });
 
   return `${parsed.status}:${parsed.version}`;
+}
+
+export class ApiClientError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly responseBody: string,
+  ) {
+    super(message);
+    this.name = "ApiClientError";
+  }
+}
+
+export interface CompetitionOverviewRequestOptions {
+  signal?: AbortSignal;
+}
+
+export interface CreateApiClientOptions {
+  apiBaseUrl?: string;
+  fetch?: typeof globalThis.fetch;
+}
+
+export interface PadelApiClient {
+  getCompetitionOverview(
+    options?: CompetitionOverviewRequestOptions,
+  ): Promise<CompetitionOverviewCollection>;
+}
+
+function buildApiUrl(apiBaseUrl: string, path: string) {
+  const normalizedBaseUrl = apiBaseUrl.endsWith("/")
+    ? apiBaseUrl.slice(0, -1)
+    : apiBaseUrl;
+
+  return `${normalizedBaseUrl}${path}`;
+}
+
+async function parseJsonWithSchema<T>(
+  response: Response,
+  schema: { parse(input: unknown): T },
+): Promise<T> {
+  const rawBody = await response.text();
+
+  if (!response.ok) {
+    throw new ApiClientError(
+      `API request failed with status ${response.status}.`,
+      response.status,
+      rawBody,
+    );
+  }
+
+  return schema.parse(JSON.parse(rawBody) as unknown);
+}
+
+export function createApiClient({
+  apiBaseUrl = "/api",
+  fetch = globalThis.fetch,
+}: CreateApiClientOptions = {}): PadelApiClient {
+  if (!fetch) {
+    throw new Error(
+      "A fetch implementation is required to create the API client.",
+    );
+  }
+
+  return {
+    async getCompetitionOverview(options = {}) {
+      const response = await fetch(
+        buildApiUrl(apiBaseUrl, competitionOverviewPath),
+        {
+          credentials: "include",
+          headers: {
+            accept: "application/json",
+          },
+          method: "GET",
+          signal: options.signal,
+        },
+      );
+
+      return parseJsonWithSchema(response, competitionOverviewCollectionSchema);
+    },
+  };
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,6 +1,6 @@
 import {
-  competitionOverviewCollectionSchema,
   type CompetitionOverviewCollection,
+  competitionOverviewCollectionSchema,
   sharedPingContract,
 } from "@padel/schemas";
 

--- a/packages/api-client/test/index.test.ts
+++ b/packages/api-client/test/index.test.ts
@@ -1,9 +1,73 @@
 import { describe, expect, it } from "vitest";
-
-import { sampleContractSummary } from "../src/index.js";
+import {
+  ApiClientError,
+  competitionOverviewPath,
+  createApiClient,
+  sampleContractSummary,
+} from "../src/index.js";
 
 describe("api-client package", () => {
   it("reads the shared schema package", () => {
     expect(sampleContractSummary()).toBe("ok:0.0.0");
+  });
+
+  it("parses the competition overview contract through the typed client", async () => {
+    const client = createApiClient({
+      apiBaseUrl: "https://padel.test/api",
+      fetch: async (input) => {
+        expect(input).toBe(`https://padel.test/api${competitionOverviewPath}`);
+
+        return new Response(
+          JSON.stringify([
+            {
+              id: "fa222204-b855-4fb0-b507-e169249e588e",
+              title: "North Circuit Masters",
+              format: "round-robin",
+              status: "open",
+              startsAt: "2026-05-03T12:00:00.000Z",
+              endsAt: "2026-05-05T21:00:00.000Z",
+              owner: {
+                id: "44e7eb17-a42b-4de8-bf34-2f8d78680d39",
+                name: "Lucia Perez",
+                email: "lucia@example.com",
+              },
+            },
+          ]),
+          {
+            headers: {
+              "content-type": "application/json",
+            },
+            status: 200,
+          },
+        );
+      },
+    });
+
+    await expect(client.getCompetitionOverview()).resolves.toMatchObject([
+      {
+        title: "North Circuit Masters",
+        status: "open",
+      },
+    ]);
+  });
+
+  it("throws a typed transport error for non-success responses", async () => {
+    const client = createApiClient({
+      fetch: async () =>
+        new Response(JSON.stringify({ message: "Backend unavailable" }), {
+          headers: {
+            "content-type": "application/json",
+          },
+          status: 503,
+        }),
+    });
+
+    await expect(client.getCompetitionOverview()).rejects.toEqual(
+      new ApiClientError(
+        "API request failed with status 503.",
+        503,
+        '{"message":"Backend unavailable"}',
+      ),
+    );
   });
 });

--- a/packages/api-client/tsconfig.build.json
+++ b/packages/api-client/tsconfig.build.json
@@ -1,6 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "baseUrl": "../..",
+    "paths": {
+      "@padel/schemas": ["packages/schemas/dist/index.d.ts"]
+    },
     "rootDir": "./src",
     "outDir": "./dist"
   },

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -5,10 +5,16 @@ export const sharedPingContract = z.object({
   version: z.literal("0.0.0"),
 });
 
+export const competitionFormatSchema = z.enum([
+  "elimination",
+  "round-robin",
+  "league",
+]);
+
 export const createCompetitionRequestSchema = z
   .object({
     title: z.string().trim().min(1),
-    format: z.enum(["elimination", "round-robin", "league"]),
+    format: competitionFormatSchema,
     startsAt: z.iso.datetime(),
     endsAt: z.iso.datetime(),
   })
@@ -25,7 +31,7 @@ export const createCompetitionRequestSchema = z
 export const createCompetitionResponseSchema = z.object({
   id: z.string().uuid(),
   title: z.string(),
-  format: z.enum(["elimination", "round-robin", "league"]),
+  format: competitionFormatSchema,
   startsAt: z.iso.datetime(),
   endsAt: z.iso.datetime(),
   ownerId: z.string(),
@@ -44,7 +50,7 @@ export const competitionOverviewItemSchema = z
   .object({
     id: z.string().uuid(),
     title: z.string(),
-    format: z.enum(["elimination", "round-robin", "league"]),
+    format: competitionFormatSchema,
     status: z.enum(["draft", "open", "closed"]),
     startsAt: z.iso.datetime(),
     endsAt: z.iso.datetime(),
@@ -62,6 +68,7 @@ export type CreateCompetitionRequest = z.infer<
 export type CreateCompetitionResponse = z.infer<
   typeof createCompetitionResponseSchema
 >;
+export type CompetitionFormat = z.infer<typeof competitionFormatSchema>;
 export type CompetitionOverviewOwner = z.infer<
   typeof competitionOverviewOwnerSchema
 >;

--- a/packages/ui/src/components/table.test.tsx
+++ b/packages/ui/src/components/table.test.tsx
@@ -5,7 +5,7 @@ import {
   TableBody,
   TableCaption,
   TableCell,
-<<<<<<< HEAD
+  TableContainer,
   TableEmptyState,
   TableFooter,
   TableHead,
@@ -17,35 +17,38 @@ import {
 describe("Table", () => {
   it("renders semantic structure for shared dense admin views", () => {
     const markup = renderToStaticMarkup(
-      <Table aria-label="Competition review table">
-        <TableCaption>Presentational table foundations only.</TableCaption>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Competition</TableHead>
-            <TableHead>Status</TableHead>
-            <TableHead>Updated</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          <TableRow state="selected">
-            <TableRowHeader>Autumn League</TableRowHeader>
-            <TableCell>Selected for bulk publish</TableCell>
-            <TableCell>Today, 14:10</TableCell>
-          </TableRow>
-          <TableRow state="warning">
-            <TableRowHeader>Junior Open</TableRowHeader>
-            <TableCell>2 waivers missing</TableCell>
-            <TableCell>8 minutes ago</TableCell>
-          </TableRow>
-        </TableBody>
-        <TableFooter>
-          <TableRow>
-            <TableCell colSpan={3}>2 competitions shown</TableCell>
-          </TableRow>
-        </TableFooter>
-      </Table>,
+      <TableContainer>
+        <Table aria-label="Competition review table">
+          <TableCaption>Presentational table foundations only.</TableCaption>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Competition</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Updated</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow state="selected">
+              <TableRowHeader>Autumn League</TableRowHeader>
+              <TableCell>Selected for bulk publish</TableCell>
+              <TableCell>Today, 14:10</TableCell>
+            </TableRow>
+            <TableRow state="warning">
+              <TableRowHeader>Junior Open</TableRowHeader>
+              <TableCell>2 waivers missing</TableCell>
+              <TableCell>8 minutes ago</TableCell>
+            </TableRow>
+          </TableBody>
+          <TableFooter>
+            <TableRow>
+              <TableCell colSpan={3}>2 competitions shown</TableCell>
+            </TableRow>
+          </TableFooter>
+        </Table>
+      </TableContainer>,
     );
 
+    expect(markup).toContain('data-slot="table-container"');
     expect(markup).toContain('data-slot="table"');
     expect(markup).toContain('data-slot="table-caption"');
     expect(markup).toContain('data-slot="table-header"');
@@ -94,39 +97,5 @@ describe("Table", () => {
     expect(markup).toContain('data-state="invalid"');
     expect(markup).toContain("Invalid medical certificate");
     expect(markup).toContain('aria-label="Invalid registration row"');
-=======
-  TableContainer,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "./table.js";
-
-describe("Table", () => {
-  it("renders semantic table foundations with row-state hooks", () => {
-    const markup = renderToStaticMarkup(
-      <TableContainer>
-        <Table>
-          <TableHeader>
-            <tr>
-              <TableHead scope="col">Competition</TableHead>
-            </tr>
-          </TableHeader>
-          <TableBody>
-            <TableRow state="warning">
-              <TableCell>Winter Open</TableCell>
-            </TableRow>
-          </TableBody>
-          <TableCaption>Shared operational table foundation.</TableCaption>
-        </Table>
-      </TableContainer>,
-    );
-
-    expect(markup).toContain('data-slot="table-container"');
-    expect(markup).toContain('data-slot="table"');
-    expect(markup).toContain('data-slot="table-head"');
-    expect(markup).toContain('data-slot="table-cell"');
-    expect(markup).toContain('data-state="warning"');
-    expect(markup).toContain("<caption");
->>>>>>> 20be765 (feat: add competition operations overview scaffold)
   });
 });

--- a/packages/ui/src/components/table.test.tsx
+++ b/packages/ui/src/components/table.test.tsx
@@ -5,6 +5,7 @@ import {
   TableBody,
   TableCaption,
   TableCell,
+<<<<<<< HEAD
   TableEmptyState,
   TableFooter,
   TableHead,
@@ -93,5 +94,39 @@ describe("Table", () => {
     expect(markup).toContain('data-state="invalid"');
     expect(markup).toContain("Invalid medical certificate");
     expect(markup).toContain('aria-label="Invalid registration row"');
+=======
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "./table.js";
+
+describe("Table", () => {
+  it("renders semantic table foundations with row-state hooks", () => {
+    const markup = renderToStaticMarkup(
+      <TableContainer>
+        <Table>
+          <TableHeader>
+            <tr>
+              <TableHead scope="col">Competition</TableHead>
+            </tr>
+          </TableHeader>
+          <TableBody>
+            <TableRow state="warning">
+              <TableCell>Winter Open</TableCell>
+            </TableRow>
+          </TableBody>
+          <TableCaption>Shared operational table foundation.</TableCaption>
+        </Table>
+      </TableContainer>,
+    );
+
+    expect(markup).toContain('data-slot="table-container"');
+    expect(markup).toContain('data-slot="table"');
+    expect(markup).toContain('data-slot="table-head"');
+    expect(markup).toContain('data-slot="table-cell"');
+    expect(markup).toContain('data-state="warning"');
+    expect(markup).toContain("<caption");
+>>>>>>> 20be765 (feat: add competition operations overview scaffold)
   });
 });

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 import { type VariantProps, cva } from "class-variance-authority";
 import * as React from "react";
 import { cn } from "../lib/utils.js";
@@ -34,6 +33,22 @@ const tableRowVariants = cva(
 export type TableRowState = NonNullable<
   VariantProps<typeof tableRowVariants>["state"]
 >;
+
+export function TableContainer({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "overflow-x-auto rounded-[1.6rem] border border-border/80 bg-card p-3 shadow-sm",
+        className,
+      )}
+      data-slot="table-container"
+      {...props}
+    />
+  );
+}
 
 export interface TableProps
   extends React.TableHTMLAttributes<HTMLTableElement> {}
@@ -242,137 +257,3 @@ export const TableEmptyState = React.forwardRef<
 ));
 
 TableEmptyState.displayName = "TableEmptyState";
-=======
-import type * as React from "react";
-import { cn } from "../lib/utils.js";
-
-const tableRowStateClassNames = {
-  default: "hover:bg-muted/45",
-  selected: "bg-secondary/80 text-secondary-foreground",
-  warning: "bg-accent/45 text-accent-foreground",
-  danger:
-    "bg-destructive/8 text-foreground shadow-[inset_4px_0_0_hsl(var(--destructive))]",
-} as const;
-
-export type TableRowState = keyof typeof tableRowStateClassNames;
-
-export function TableContainer({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) {
-  return (
-    <div
-      className={cn(
-        "overflow-hidden rounded-[1.5rem] border border-border/80 bg-card/90 shadow-sm",
-        className,
-      )}
-      data-slot="table-container"
-      {...props}
-    />
-  );
-}
-
-export function Table({
-  className,
-  ...props
-}: React.TableHTMLAttributes<HTMLTableElement>) {
-  return (
-    <div className="overflow-x-auto" data-slot="table-scroll">
-      <table
-        className={cn("min-w-full border-collapse text-left", className)}
-        data-slot="table"
-        {...props}
-      />
-    </div>
-  );
-}
-
-export function TableHeader({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLTableSectionElement>) {
-  return (
-    <thead
-      className={cn("bg-muted/55", className)}
-      data-slot="table-header"
-      {...props}
-    />
-  );
-}
-
-export function TableBody({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLTableSectionElement>) {
-  return <tbody className={cn(className)} data-slot="table-body" {...props} />;
-}
-
-export interface TableRowProps
-  extends React.HTMLAttributes<HTMLTableRowElement> {
-  state?: TableRowState;
-}
-
-export function TableRow({
-  className,
-  state = "default",
-  ...props
-}: TableRowProps) {
-  return (
-    <tr
-      className={cn(
-        "border-t border-border/70 transition-colors duration-150 first:border-t-0",
-        tableRowStateClassNames[state],
-        className,
-      )}
-      data-slot="table-row"
-      data-state={state}
-      {...props}
-    />
-  );
-}
-
-export function TableHead({
-  className,
-  ...props
-}: React.ThHTMLAttributes<HTMLTableCellElement>) {
-  return (
-    <th
-      className={cn(
-        "px-4 py-3 text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-muted-foreground",
-        className,
-      )}
-      data-slot="table-head"
-      {...props}
-    />
-  );
-}
-
-export function TableCell({
-  className,
-  ...props
-}: React.TdHTMLAttributes<HTMLTableCellElement>) {
-  return (
-    <td
-      className={cn("px-4 py-4 align-top text-sm leading-6", className)}
-      data-slot="table-cell"
-      {...props}
-    />
-  );
-}
-
-export function TableCaption({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLTableCaptionElement>) {
-  return (
-    <caption
-      className={cn(
-        "border-t border-border/70 px-4 py-3 text-sm text-muted-foreground caption-bottom",
-        className,
-      )}
-      data-slot="table-caption"
-      {...props}
-    />
-  );
-}
->>>>>>> 20be765 (feat: add competition operations overview scaffold)

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 import { type VariantProps, cva } from "class-variance-authority";
 import * as React from "react";
 import { cn } from "../lib/utils.js";
@@ -241,3 +242,137 @@ export const TableEmptyState = React.forwardRef<
 ));
 
 TableEmptyState.displayName = "TableEmptyState";
+=======
+import type * as React from "react";
+import { cn } from "../lib/utils.js";
+
+const tableRowStateClassNames = {
+  default: "hover:bg-muted/45",
+  selected: "bg-secondary/80 text-secondary-foreground",
+  warning: "bg-accent/45 text-accent-foreground",
+  danger:
+    "bg-destructive/8 text-foreground shadow-[inset_4px_0_0_hsl(var(--destructive))]",
+} as const;
+
+export type TableRowState = keyof typeof tableRowStateClassNames;
+
+export function TableContainer({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-[1.5rem] border border-border/80 bg-card/90 shadow-sm",
+        className,
+      )}
+      data-slot="table-container"
+      {...props}
+    />
+  );
+}
+
+export function Table({
+  className,
+  ...props
+}: React.TableHTMLAttributes<HTMLTableElement>) {
+  return (
+    <div className="overflow-x-auto" data-slot="table-scroll">
+      <table
+        className={cn("min-w-full border-collapse text-left", className)}
+        data-slot="table"
+        {...props}
+      />
+    </div>
+  );
+}
+
+export function TableHeader({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return (
+    <thead
+      className={cn("bg-muted/55", className)}
+      data-slot="table-header"
+      {...props}
+    />
+  );
+}
+
+export function TableBody({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return <tbody className={cn(className)} data-slot="table-body" {...props} />;
+}
+
+export interface TableRowProps
+  extends React.HTMLAttributes<HTMLTableRowElement> {
+  state?: TableRowState;
+}
+
+export function TableRow({
+  className,
+  state = "default",
+  ...props
+}: TableRowProps) {
+  return (
+    <tr
+      className={cn(
+        "border-t border-border/70 transition-colors duration-150 first:border-t-0",
+        tableRowStateClassNames[state],
+        className,
+      )}
+      data-slot="table-row"
+      data-state={state}
+      {...props}
+    />
+  );
+}
+
+export function TableHead({
+  className,
+  ...props
+}: React.ThHTMLAttributes<HTMLTableCellElement>) {
+  return (
+    <th
+      className={cn(
+        "px-4 py-3 text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-muted-foreground",
+        className,
+      )}
+      data-slot="table-head"
+      {...props}
+    />
+  );
+}
+
+export function TableCell({
+  className,
+  ...props
+}: React.TdHTMLAttributes<HTMLTableCellElement>) {
+  return (
+    <td
+      className={cn("px-4 py-4 align-top text-sm leading-6", className)}
+      data-slot="table-cell"
+      {...props}
+    />
+  );
+}
+
+export function TableCaption({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLTableCaptionElement>) {
+  return (
+    <caption
+      className={cn(
+        "border-t border-border/70 px-4 py-3 text-sm text-muted-foreground caption-bottom",
+        className,
+      )}
+      data-slot="table-caption"
+      {...props}
+    />
+  );
+}
+>>>>>>> 20be765 (feat: add competition operations overview scaffold)

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -88,6 +88,7 @@ export {
   TableBody,
   TableCaption,
   TableCell,
+  TableContainer,
   TableEmptyState,
   TableFooter,
   TableHead,
@@ -104,9 +105,9 @@ export type {
   TableHeadProps,
   TableHeaderProps,
   TableProps,
+  TableRowState,
   TableRowHeaderProps,
   TableRowProps,
-  TableRowState,
 } from "./components/table.js";
 export { Field } from "./components/field.js";
 export type { FieldProps } from "./components/field.js";
@@ -171,6 +172,18 @@ export {
 export type { SwitchProps } from "./components/switch.js";
 export { Textarea } from "./components/textarea.js";
 export type { TextareaProps } from "./components/textarea.js";
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+  type TableRowProps,
+  type TableRowState,
+} from "./components/table.js";
 export {
   Toast,
   ToastAction,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -173,18 +173,6 @@ export type { SwitchProps } from "./components/switch.js";
 export { Textarea } from "./components/textarea.js";
 export type { TextareaProps } from "./components/textarea.js";
 export {
-  Table,
-  TableBody,
-  TableCaption,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableHeader,
-  TableRow,
-  type TableRowProps,
-  type TableRowState,
-} from "./components/table.js";
-export {
   Toast,
   ToastAction,
   ToastClose,

--- a/packages/ui/src/table.stories.tsx
+++ b/packages/ui/src/table.stories.tsx
@@ -4,11 +4,18 @@ import {
   TableBody,
   TableCaption,
   TableCell,
+<<<<<<< HEAD
   TableEmptyState,
   TableHead,
   TableHeader,
   TableRow,
   TableRowHeader,
+=======
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+>>>>>>> 20be765 (feat: add competition operations overview scaffold)
 } from "./components/table.js";
 
 const meta: Meta<typeof Table> = {
@@ -16,6 +23,7 @@ const meta: Meta<typeof Table> = {
   component: Table,
   tags: ["autodocs"],
   parameters: {
+<<<<<<< HEAD
     layout: "padded",
     docs: {
       description: {
@@ -38,6 +46,13 @@ Keep the foundation presentational. Use row-state styling and empty-state compos
 Known misuse patterns
 Avoid turning this into a generic data-grid abstraction or adding boolean flags for every workflow mode.
         `.trim(),
+=======
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Reusable table foundations for dense operational screens. Sorting, filtering, pagination, routing, and fetching stay outside the shared package.",
+>>>>>>> 20be765 (feat: add competition operations overview scaffold)
       },
     },
   },
@@ -47,6 +62,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+<<<<<<< HEAD
 export const Default: Story = {
   render: () => (
     <div className="overflow-x-auto rounded-[1.6rem] border border-border/80 bg-card p-3 shadow-sm">
@@ -174,5 +190,51 @@ export const EmptyTable: Story = {
         </TableBody>
       </Table>
     </div>
+=======
+export const OperationalStates: Story = {
+  render: () => (
+    <TableContainer className="w-[960px] max-w-full">
+      <Table>
+        <TableHeader>
+          <tr>
+            <TableHead scope="col">Competition</TableHead>
+            <TableHead scope="col">Schedule</TableHead>
+            <TableHead scope="col">Operations</TableHead>
+            <TableHead scope="col">Next action</TableHead>
+          </tr>
+        </TableHeader>
+        <TableBody>
+          <TableRow state="danger">
+            <TableCell className="font-semibold">
+              North Circuit Masters
+            </TableCell>
+            <TableCell>May 3 to May 5</TableCell>
+            <TableCell>2 missing results, 1 invalid roster</TableCell>
+            <TableCell>Resolve blocked semifinal score</TableCell>
+          </TableRow>
+          <TableRow state="warning">
+            <TableCell className="font-semibold">
+              Club League Apertura
+            </TableCell>
+            <TableCell>May 8 to May 20</TableCell>
+            <TableCell>4 pending approvals</TableCell>
+            <TableCell>Review late category confirmations</TableCell>
+          </TableRow>
+          <TableRow state="selected">
+            <TableCell className="font-semibold">
+              Saturday Social Draw
+            </TableCell>
+            <TableCell>May 10</TableCell>
+            <TableCell>Ready for structure generation</TableCell>
+            <TableCell>Publish draw after organizer check</TableCell>
+          </TableRow>
+        </TableBody>
+        <TableCaption>
+          Keep table foundations presentational. Route-owned filtering and
+          workflow actions belong in `apps/web`.
+        </TableCaption>
+      </Table>
+    </TableContainer>
+>>>>>>> 20be765 (feat: add competition operations overview scaffold)
   ),
 };

--- a/packages/ui/src/table.stories.tsx
+++ b/packages/ui/src/table.stories.tsx
@@ -4,18 +4,12 @@ import {
   TableBody,
   TableCaption,
   TableCell,
-<<<<<<< HEAD
+  TableContainer,
   TableEmptyState,
   TableHead,
   TableHeader,
   TableRow,
   TableRowHeader,
-=======
-  TableContainer,
-  TableHead,
-  TableHeader,
-  TableRow,
->>>>>>> 20be765 (feat: add competition operations overview scaffold)
 } from "./components/table.js";
 
 const meta: Meta<typeof Table> = {
@@ -23,7 +17,6 @@ const meta: Meta<typeof Table> = {
   component: Table,
   tags: ["autodocs"],
   parameters: {
-<<<<<<< HEAD
     layout: "padded",
     docs: {
       description: {
@@ -46,13 +39,6 @@ Keep the foundation presentational. Use row-state styling and empty-state compos
 Known misuse patterns
 Avoid turning this into a generic data-grid abstraction or adding boolean flags for every workflow mode.
         `.trim(),
-=======
-    layout: "centered",
-    docs: {
-      description: {
-        component:
-          "Reusable table foundations for dense operational screens. Sorting, filtering, pagination, routing, and fetching stay outside the shared package.",
->>>>>>> 20be765 (feat: add competition operations overview scaffold)
       },
     },
   },
@@ -62,10 +48,9 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-<<<<<<< HEAD
 export const Default: Story = {
   render: () => (
-    <div className="overflow-x-auto rounded-[1.6rem] border border-border/80 bg-card p-3 shadow-sm">
+    <TableContainer>
       <Table className="min-w-[760px]">
         <TableCaption>
           Dense operational table foundation with stable shared semantics.
@@ -99,7 +84,7 @@ export const Default: Story = {
           </TableRow>
         </TableBody>
       </Table>
-    </div>
+    </TableContainer>
   ),
 };
 
@@ -113,7 +98,7 @@ export const RowStates: Story = {
     },
   },
   render: () => (
-    <div className="overflow-x-auto rounded-[1.6rem] border border-border/80 bg-card p-3 shadow-sm">
+    <TableContainer>
       <Table className="min-w-[820px]">
         <TableHeader>
           <TableRow>
@@ -154,7 +139,7 @@ export const RowStates: Story = {
           </TableRow>
         </TableBody>
       </Table>
-    </div>
+    </TableContainer>
   ),
 };
 
@@ -168,7 +153,7 @@ export const EmptyTable: Story = {
     },
   },
   render: () => (
-    <div className="overflow-x-auto rounded-[1.6rem] border border-border/80 bg-card p-3 shadow-sm">
+    <TableContainer>
       <Table className="min-w-[760px]">
         <TableHeader>
           <TableRow>
@@ -189,52 +174,6 @@ export const EmptyTable: Story = {
           </TableRow>
         </TableBody>
       </Table>
-    </div>
-=======
-export const OperationalStates: Story = {
-  render: () => (
-    <TableContainer className="w-[960px] max-w-full">
-      <Table>
-        <TableHeader>
-          <tr>
-            <TableHead scope="col">Competition</TableHead>
-            <TableHead scope="col">Schedule</TableHead>
-            <TableHead scope="col">Operations</TableHead>
-            <TableHead scope="col">Next action</TableHead>
-          </tr>
-        </TableHeader>
-        <TableBody>
-          <TableRow state="danger">
-            <TableCell className="font-semibold">
-              North Circuit Masters
-            </TableCell>
-            <TableCell>May 3 to May 5</TableCell>
-            <TableCell>2 missing results, 1 invalid roster</TableCell>
-            <TableCell>Resolve blocked semifinal score</TableCell>
-          </TableRow>
-          <TableRow state="warning">
-            <TableCell className="font-semibold">
-              Club League Apertura
-            </TableCell>
-            <TableCell>May 8 to May 20</TableCell>
-            <TableCell>4 pending approvals</TableCell>
-            <TableCell>Review late category confirmations</TableCell>
-          </TableRow>
-          <TableRow state="selected">
-            <TableCell className="font-semibold">
-              Saturday Social Draw
-            </TableCell>
-            <TableCell>May 10</TableCell>
-            <TableCell>Ready for structure generation</TableCell>
-            <TableCell>Publish draw after organizer check</TableCell>
-          </TableRow>
-        </TableBody>
-        <TableCaption>
-          Keep table foundations presentational. Route-owned filtering and
-          workflow actions belong in `apps/web`.
-        </TableCaption>
-      </Table>
     </TableContainer>
->>>>>>> 20be765 (feat: add competition operations overview scaffold)
   ),
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,12 @@ importers:
       '@padel/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@tanstack/react-query':
+        specifier: ^5.100.7
+        version: 5.100.7(react@19.2.5)
+      '@tanstack/react-router':
+        specifier: ^1.169.1
+        version: 1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: ^19.2.0
         version: 19.2.5
@@ -166,6 +172,9 @@ importers:
         specifier: ^19.2.0
         version: 19.2.5(react@19.2.5)
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/react':
         specifier: ^19.2.2
         version: 19.2.14
@@ -2132,6 +2141,39 @@ packages:
   '@tailwindcss/postcss@4.2.4':
     resolution: {integrity: sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==}
 
+  '@tanstack/history@1.161.6':
+    resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/query-core@5.100.7':
+    resolution: {integrity: sha512-5R7i6ENJLhVeeJrrUz7jKBXUXv/BJrxf9FQJSkR13bPrb3zOcE8A0Z0PxYCcsKPOsiIlTibrBL/zZbtUO1TFyQ==}
+
+  '@tanstack/react-query@5.100.7':
+    resolution: {integrity: sha512-LoISYWz8dOOuQbeIctF8K6yi42TWtR1WPGpwGuRUpF3u79JVVIg/PVR0MQdIA0VSHqD/ydf/b7PhKTkg3I4fLQ==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@tanstack/react-router@1.169.1':
+    resolution: {integrity: sha512-MBtQKSvac3OCcsSa6oBpDrrN90IV47I6Gtv05NxhbFVh+gVjtqvs6HSU4XM9+y5sHZPgS+35eArflX4vM8GEnQ==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.169.1':
+    resolution: {integrity: sha512-x+2gIGKTTE1qAn7tLieGfrB5ciOviDmmi2ox9fAWUubRV+yTU5ruGFXocoCIWF+lB+SOtnHjo2E9BLSWyYoEmA==}
+    engines: {node: '>=20.19'}
+    hasBin: true
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
     engines: {node: '>=18'}
@@ -2848,6 +2890,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
@@ -3500,6 +3545,10 @@ packages:
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
+
+  isbot@5.1.39:
+    resolution: {integrity: sha512-obH0yYahGXdzNxo+djmHhBYThUKDkz565cxkIlt2L9hXfv1NlaLKoDBHo6KxXsYrIXx2RK3x5vY36CfZcobxEw==}
+    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -4395,6 +4444,16 @@ packages:
   seq-queue@0.0.5:
     resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
 
+  seroval-plugins@1.5.2:
+    resolution: {integrity: sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.2:
+    resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
+    engines: {node: '>=10'}
+
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
@@ -4753,6 +4812,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -6818,6 +6882,40 @@ snapshots:
       postcss: 8.5.12
       tailwindcss: 4.2.4
 
+  '@tanstack/history@1.161.6': {}
+
+  '@tanstack/query-core@5.100.7': {}
+
+  '@tanstack/react-query@5.100.7(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-core': 5.100.7
+      react: 19.2.5
+
+  '@tanstack/react-router@1.169.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/history': 1.161.6
+      '@tanstack/react-store': 0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/router-core': 1.169.1
+      isbot: 5.1.39
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@tanstack/react-store@0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
+
+  '@tanstack/router-core@1.169.1':
+    dependencies:
+      '@tanstack/history': 1.161.6
+      cookie-es: 3.1.1
+      seroval: 1.5.2
+      seroval-plugins: 1.5.2(seroval@1.5.2)
+
+  '@tanstack/store@0.9.3': {}
+
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -7588,6 +7686,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-es@3.1.1: {}
+
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
@@ -8235,6 +8335,8 @@ snapshots:
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
+
+  isbot@5.1.39: {}
 
   isexe@2.0.0: {}
 
@@ -9174,6 +9276,12 @@ snapshots:
   seq-queue@0.0.5:
     optional: true
 
+  seroval-plugins@1.5.2(seroval@1.5.2):
+    dependencies:
+      seroval: 1.5.2
+
+  seroval@1.5.2: {}
+
   serve-static@2.2.1:
     dependencies:
       encodeurl: 2.0.0
@@ -9509,6 +9617,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
+
+  use-sync-external-store@1.6.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   util-deprecate@1.0.2: {}
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,14 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022", "DOM"],
+    "baseUrl": ".",
+    "paths": {
+      "@padel/api-client": ["packages/api-client/src/index.ts"],
+      "@padel/config": ["packages/config/src/index.ts"],
+      "@padel/schemas": ["packages/schemas/src/index.ts"],
+      "@padel/ui": ["packages/ui/src/index.ts"],
+      "@padel/ui/styles.css": ["packages/ui/src/styles.css"]
+    },
     "strict": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,19 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@padel/api-client": path.resolve(
+        __dirname,
+        "packages/api-client/src/index.ts",
+      ),
+      "@padel/schemas": path.resolve(__dirname, "packages/schemas/src/index.ts"),
+      "@padel/ui": path.resolve(__dirname, "packages/ui/src/index.ts"),
+      "@padel/ui/styles.css": path.resolve(
+        __dirname,
+        "packages/ui/src/styles.css",
+      ),
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,10 @@ export default defineConfig({
         __dirname,
         "packages/api-client/src/index.ts",
       ),
-      "@padel/schemas": path.resolve(__dirname, "packages/schemas/src/index.ts"),
+      "@padel/schemas": path.resolve(
+        __dirname,
+        "packages/schemas/src/index.ts",
+      ),
       "@padel/ui": path.resolve(__dirname, "packages/ui/src/index.ts"),
       "@padel/ui/styles.css": path.resolve(
         __dirname,


### PR DESCRIPTION
## Summary
- add the first authenticated competition operations overview route scaffold in `apps/web` using TanStack Router and TanStack Query
- add the typed competition overview contract and transport client surface in `packages/schemas` and `packages/api-client`
- add a shared table foundation in `packages/ui` plus route and client tests for loading, empty, error, and populated states

## Testing
- `pnpm --filter @padel/api-client lint typecheck test`
- `pnpm --filter @padel/ui lint typecheck test`
- `pnpm --filter @padel/web lint typecheck test`

## Linked Issue
- Closes #37
