### PR TITLE
feat: add frontend auth entry flows

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "@padel/api-client": "workspace:*",
     "@padel/schemas": "workspace:*",
     "@padel/ui": "workspace:*",
+    "@tanstack/react-form": "1.29.1",
     "@tanstack/react-query": "^5.100.7",
     "@tanstack/react-router": "^1.169.1",
     "react": "^19.2.0",
@@ -21,8 +22,10 @@
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "14.6.1",
     "@types/react": "^19.2.2",
-    "@types/react-dom": "^19.2.2"
+    "@types/react-dom": "^19.2.2",
+    "jsdom": "26.1.0"
   },
   "nx": {
     "tags": ["type:app", "scope:web", "platform:frontend"]

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -1,5 +1,13 @@
-import { QueryClient, QueryClientProvider, type QueryClient as QueryClientType } from "@tanstack/react-query";
-import { type RouterHistory, RouterProvider } from "@tanstack/react-router";
+import {
+  QueryClient,
+  QueryClientProvider,
+  type QueryClient as QueryClientType,
+} from "@tanstack/react-query";
+import {
+  type AnyRouter,
+  type RouterHistory,
+  RouterProvider,
+} from "@tanstack/react-router";
 import { useState } from "react";
 
 import { type PadelApiClient, createApiClient } from "@padel/api-client";
@@ -14,7 +22,7 @@ export interface AppRuntime {
 
 interface LegacyAppProps {
   queryClient: QueryClientType;
-  router: AppRouter;
+  router: AnyRouter;
 }
 
 interface RuntimeAppProps {

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -1,16 +1,94 @@
-import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { RouterProvider } from "@tanstack/react-router";
-import type { createWebRouter } from "./router.js";
+import { QueryClient, QueryClientProvider, type QueryClient as QueryClientType } from "@tanstack/react-query";
+import { type RouterHistory, RouterProvider } from "@tanstack/react-router";
+import { useState } from "react";
 
-interface AppProps {
+import { type PadelApiClient, createApiClient } from "@padel/api-client";
+
+import { type AppRouter, createAppRouter } from "./routes.js";
+
+export interface AppRuntime {
+  apiClient: PadelApiClient;
   queryClient: QueryClient;
-  router: ReturnType<typeof createWebRouter>;
+  router: AppRouter;
 }
 
-export function App({ queryClient, router }: AppProps) {
+interface LegacyAppProps {
+  queryClient: QueryClientType;
+  router: AppRouter;
+}
+
+interface RuntimeAppProps {
+  runtime?: AppRuntime;
+}
+
+type AppProps = LegacyAppProps | RuntimeAppProps;
+
+function getDefaultApiBaseUrl() {
+  if (typeof window !== "undefined") {
+    return window.location.origin;
+  }
+
+  return "http://localhost:3000";
+}
+
+export function createAppRuntime(options?: {
+  apiClient?: PadelApiClient;
+  history?: RouterHistory;
+  queryClient?: QueryClient;
+}) {
+  const queryClient =
+    options?.queryClient ??
+    new QueryClient({
+      defaultOptions: {
+        mutations: {
+          retry: false,
+        },
+        queries: {
+          retry: false,
+        },
+      },
+    });
+  const apiClient =
+    options?.apiClient ??
+    createApiClient({
+      baseUrl: getDefaultApiBaseUrl(),
+    });
+
+  return {
+    apiClient,
+    queryClient,
+    router: createAppRouter(
+      {
+        apiClient,
+        queryClient,
+      },
+      {
+        history: options?.history,
+      },
+    ),
+  } satisfies AppRuntime;
+}
+
+function isLegacyProps(props: AppProps): props is LegacyAppProps {
+  return "queryClient" in props && "router" in props;
+}
+
+export function App(props: AppProps) {
+  const [resolvedRuntime] = useState(() => {
+    if (isLegacyProps(props)) {
+      return {
+        apiClient: props.router.options.context.apiClient,
+        queryClient: props.queryClient,
+        router: props.router,
+      } satisfies AppRuntime;
+    }
+
+    return props.runtime ?? createAppRuntime();
+  });
+
   return (
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+    <QueryClientProvider client={resolvedRuntime.queryClient}>
+      <RouterProvider router={resolvedRuntime.router} />
     </QueryClientProvider>
   );
 }

--- a/apps/web/src/auth.ts
+++ b/apps/web/src/auth.ts
@@ -1,0 +1,71 @@
+import type { PadelApiClient } from "@padel/api-client";
+import type { QueryClient } from "@tanstack/react-query";
+import { queryOptions } from "@tanstack/react-query";
+
+export const authFlashMessageQueryKey = ["auth", "flash-message"] as const;
+export const authSessionQueryKey = ["auth", "session"] as const;
+
+export function buildFieldErrorMap<TValues extends Record<string, unknown>>(
+  issues: Array<{
+    message: string;
+    path: PropertyKey[];
+  }>,
+) {
+  const errors = {} as Partial<Record<Extract<keyof TValues, string>, string>>;
+
+  for (const issue of issues) {
+    const [segment] = issue.path;
+
+    if (typeof segment !== "string" || segment in errors) {
+      continue;
+    }
+
+    errors[segment as Extract<keyof TValues, string>] = issue.message;
+  }
+
+  return errors;
+}
+
+export function clearFieldError<TValues extends Record<string, unknown>>(
+  errors: Partial<Record<Extract<keyof TValues, string>, string>>,
+  name: Extract<keyof TValues, string>,
+) {
+  if (!(name in errors)) {
+    return errors;
+  }
+
+  const nextErrors = { ...errors };
+  delete nextErrors[name];
+  return nextErrors;
+}
+
+export function getAuthErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof Error && error.message.length > 0) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
+export function getSessionQueryOptions(apiClient: PadelApiClient) {
+  return queryOptions({
+    queryFn: () => apiClient.getCurrentSession(),
+    queryKey: authSessionQueryKey,
+    staleTime: 30_000,
+  });
+}
+
+export function refreshSession(
+  queryClient: QueryClient,
+  apiClient: PadelApiClient,
+) {
+  void queryClient.invalidateQueries({
+    exact: true,
+    queryKey: authSessionQueryKey,
+  });
+
+  return queryClient.fetchQuery({
+    ...getSessionQueryOptions(apiClient),
+    staleTime: 0,
+  });
+}

--- a/apps/web/src/contracts.ts
+++ b/apps/web/src/contracts.ts
@@ -1,5 +1,0 @@
-import { sharedPingContract } from "@padel/schemas";
-
-export function getWebContractVersion() {
-  return sharedPingContract.shape.version.value;
-}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,43 +1,16 @@
-import { createApiClient } from "@padel/api-client";
-import { QueryClient } from "@tanstack/react-query";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "@padel/ui/styles.css";
 
 import { App } from "./app.js";
-import { createWebRouter } from "./router.js";
-import { createScaffoldApiFetch } from "./scaffold-api-fetch.js";
 
 const container = document.getElementById("root");
 
 if (container) {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        staleTime: 30_000,
-      },
-    },
-  });
-
-  const apiClient = createApiClient({
-    fetch: createScaffoldApiFetch(),
-  });
-
-  const router = createWebRouter({
-    apiClient,
-    auth: {
-      isAuthenticated: true,
-      roleLabel: "Competition operations",
-      userName: "Operations desk",
-    },
-    queryClient,
-  });
-
   const root = createRoot(container);
   root.render(
     <StrictMode>
-      <App queryClient={queryClient} router={router} />
+      <App />
     </StrictMode>,
   );
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -12,6 +12,7 @@ import {
 } from "@padel/ui";
 import { type QueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import {
+  type AnyRouter,
   type ErrorComponentProps,
   Link,
   Outlet,
@@ -185,6 +186,6 @@ export function createWebRouter({
 
 declare module "@tanstack/react-router" {
   interface Register {
-    router: ReturnType<typeof createWebRouter>;
+    router: AnyRouter;
   }
 }

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -1,0 +1,669 @@
+import {
+  type SignInEmailRequest,
+  type SignUpEmailRequest,
+  signInEmailRequestSchema,
+  signUpEmailRequestSchema,
+} from "@padel/schemas";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Field,
+  InlineAlert,
+  InlineAlertDescription,
+  InlineAlertTitle,
+  Input,
+} from "@padel/ui";
+import { useForm } from "@tanstack/react-form";
+import { type QueryClient, useMutation, useQuery } from "@tanstack/react-query";
+import {
+  Link,
+  Outlet,
+  type RouterHistory,
+  createRootRouteWithContext,
+  createRoute,
+  createRouter,
+  redirect,
+  useNavigate,
+  useRouter,
+} from "@tanstack/react-router";
+import { startTransition, useState } from "react";
+
+import type { PadelApiClient } from "@padel/api-client";
+
+import {
+  authFlashMessageQueryKey,
+  buildFieldErrorMap,
+  clearFieldError,
+  getAuthErrorMessage,
+  getSessionQueryOptions,
+  refreshSession,
+} from "./auth.js";
+
+export interface AppRouterContext {
+  apiClient: PadelApiClient;
+  queryClient: QueryClient;
+}
+
+function AuthFrame({
+  children,
+  eyebrow,
+  title,
+  description,
+}: {
+  children: React.ReactNode;
+  description: string;
+  eyebrow: string;
+  title: string;
+}) {
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(14,165,233,0.12),_transparent_40%),linear-gradient(180deg,_hsl(var(--background)),_#f8fafc)] px-6 py-12 text-foreground">
+      <div className="mx-auto flex min-h-[calc(100vh-6rem)] max-w-6xl items-center justify-center">
+        <div className="grid w-full max-w-5xl gap-10 lg:grid-cols-[1.1fr_0.9fr]">
+          <section className="flex flex-col justify-center gap-6">
+            <p className="text-sm font-medium uppercase tracking-[0.22em] text-primary">
+              {eyebrow}
+            </p>
+            <div className="space-y-4">
+              <h1 className="max-w-xl text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
+                {title}
+              </h1>
+              <p className="max-w-xl text-base leading-7 text-muted-foreground sm:text-lg">
+                {description}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-3 text-sm text-muted-foreground">
+              <span className="rounded-full border border-border/80 bg-background/80 px-3 py-1.5">
+                TanStack Router entry guards
+              </span>
+              <span className="rounded-full border border-border/80 bg-background/80 px-3 py-1.5">
+                TanStack Form ownership
+              </span>
+              <span className="rounded-full border border-border/80 bg-background/80 px-3 py-1.5">
+                Better Auth session contracts
+              </span>
+            </div>
+          </section>
+
+          <section>{children}</section>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function AuthLayout() {
+  return <Outlet />;
+}
+
+function readRouterContext() {
+  const router = useRouter();
+  return router.options.context;
+}
+
+function LoginPage() {
+  const navigate = useNavigate();
+  const { apiClient, queryClient } = readRouterContext();
+  const [fieldErrors, setFieldErrors] = useState<
+    Partial<Record<keyof SignInEmailRequest, string>>
+  >({});
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const signInMutation = useMutation({
+    mutationFn: (values: SignInEmailRequest) => apiClient.signIn(values),
+    onError: (error) => {
+      setFormError(
+        getAuthErrorMessage(
+          error,
+          "We could not sign you in. Please try again.",
+        ),
+      );
+    },
+    onSuccess: async () => {
+      queryClient.setQueryData(
+        authFlashMessageQueryKey,
+        "Signed in successfully. Your authenticated workspace is ready.",
+      );
+      await refreshSession(queryClient, apiClient);
+      startTransition(() => {
+        void navigate({ to: "/dashboard" });
+      });
+    },
+  });
+
+  const form = useForm({
+    defaultValues: {
+      email: "",
+      password: "",
+      rememberMe: true,
+    } satisfies SignInEmailRequest,
+    onSubmit: async ({ value }) => {
+      const parsed = signInEmailRequestSchema.safeParse(value);
+
+      if (!parsed.success) {
+        setFieldErrors(
+          buildFieldErrorMap<SignInEmailRequest>(parsed.error.issues),
+        );
+        setFormError("Please correct the highlighted fields and try again.");
+        return;
+      }
+
+      setFieldErrors({});
+      setFormError(null);
+
+      try {
+        await signInMutation.mutateAsync(parsed.data);
+      } catch {
+        return;
+      }
+    },
+  });
+
+  return (
+    <AuthFrame
+      description="Sign in with the Better Auth session flow already owned by the backend so admin and operator routes can enforce a real identity boundary."
+      eyebrow="Authentication"
+      title="Welcome back to your competition workspace."
+    >
+      <Card className="border-border/80 bg-background/95 shadow-xl shadow-slate-950/5 backdrop-blur">
+        <CardHeader>
+          <CardTitle>Sign in</CardTitle>
+          <CardDescription>
+            Use the account you created for competition operations.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-6">
+          {formError ? (
+            <InlineAlert variant="blocked">
+              <InlineAlertTitle variant="blocked">
+                Sign-in could not continue
+              </InlineAlertTitle>
+              <InlineAlertDescription>{formError}</InlineAlertDescription>
+            </InlineAlert>
+          ) : null}
+
+          <form
+            className="grid gap-5"
+            noValidate
+            onSubmit={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              void form.handleSubmit();
+            }}
+          >
+            <form.Field name="email">
+              {(field) => (
+                <Field
+                  description="Use the email address tied to your organizer account."
+                  error={fieldErrors.email}
+                  label="Email"
+                  required
+                >
+                  <Input
+                    autoComplete="email"
+                    onBlur={field.handleBlur}
+                    onChange={(event) => {
+                      setFieldErrors((current) =>
+                        clearFieldError(current, "email"),
+                      );
+                      setFormError(null);
+                      field.handleChange(event.target.value);
+                    }}
+                    placeholder="organizer@example.com"
+                    type="email"
+                    value={field.state.value}
+                  />
+                </Field>
+              )}
+            </form.Field>
+
+            <form.Field name="password">
+              {(field) => (
+                <Field
+                  description="Passwords stay at the backend auth boundary."
+                  error={fieldErrors.password}
+                  label="Password"
+                  required
+                >
+                  <Input
+                    autoComplete="current-password"
+                    onBlur={field.handleBlur}
+                    onChange={(event) => {
+                      setFieldErrors((current) =>
+                        clearFieldError(current, "password"),
+                      );
+                      setFormError(null);
+                      field.handleChange(event.target.value);
+                    }}
+                    placeholder="Enter your password"
+                    type="password"
+                    value={field.state.value}
+                  />
+                </Field>
+              )}
+            </form.Field>
+
+            <div className="grid gap-3 pt-1">
+              <Button disabled={signInMutation.isPending} type="submit">
+                {signInMutation.isPending ? "Signing in..." : "Sign in"}
+              </Button>
+              <p className="text-sm leading-6 text-muted-foreground">
+                Need an account?{" "}
+                <Link
+                  className="font-medium text-primary underline-offset-4 hover:underline"
+                  to="/register"
+                >
+                  Create one here
+                </Link>
+                .
+              </p>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </AuthFrame>
+  );
+}
+
+function RegisterPage() {
+  const navigate = useNavigate();
+  const { apiClient, queryClient } = readRouterContext();
+  const [fieldErrors, setFieldErrors] = useState<
+    Partial<Record<keyof SignUpEmailRequest, string>>
+  >({});
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const signUpMutation = useMutation({
+    mutationFn: (values: SignUpEmailRequest) => apiClient.signUp(values),
+    onError: (error) => {
+      setFormError(
+        getAuthErrorMessage(
+          error,
+          "We could not create your account. Please review the details and try again.",
+        ),
+      );
+    },
+    onSuccess: async () => {
+      queryClient.setQueryData(
+        authFlashMessageQueryKey,
+        "Account created successfully. Your authenticated dashboard is ready.",
+      );
+      await refreshSession(queryClient, apiClient);
+      startTransition(() => {
+        void navigate({ to: "/dashboard" });
+      });
+    },
+  });
+
+  const form = useForm({
+    defaultValues: {
+      email: "",
+      name: "",
+      password: "",
+      rememberMe: true,
+    } satisfies SignUpEmailRequest,
+    onSubmit: async ({ value }) => {
+      const parsed = signUpEmailRequestSchema.safeParse(value);
+
+      if (!parsed.success) {
+        setFieldErrors(
+          buildFieldErrorMap<SignUpEmailRequest>(parsed.error.issues),
+        );
+        setFormError("Please correct the highlighted fields and try again.");
+        return;
+      }
+
+      setFieldErrors({});
+      setFormError(null);
+
+      try {
+        await signUpMutation.mutateAsync(parsed.data);
+      } catch {
+        return;
+      }
+    },
+  });
+
+  return (
+    <AuthFrame
+      description="Create the first user-facing auth entry point on top of the backend-owned Better Auth contracts and land new organizers directly into an authenticated shell."
+      eyebrow="Self-service access"
+      title="Create an organizer account without leaving the product flow."
+    >
+      <Card className="border-border/80 bg-background/95 shadow-xl shadow-slate-950/5 backdrop-blur">
+        <CardHeader>
+          <CardTitle>Register</CardTitle>
+          <CardDescription>
+            Start with a simple email and password account for competition
+            administration.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-6">
+          {formError ? (
+            <InlineAlert variant="blocked">
+              <InlineAlertTitle variant="blocked">
+                Registration could not continue
+              </InlineAlertTitle>
+              <InlineAlertDescription>{formError}</InlineAlertDescription>
+            </InlineAlert>
+          ) : null}
+
+          <form
+            className="grid gap-5"
+            noValidate
+            onSubmit={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              void form.handleSubmit();
+            }}
+          >
+            <form.Field name="name">
+              {(field) => (
+                <Field
+                  description="Shown as the owner context on authenticated operational screens."
+                  error={fieldErrors.name}
+                  label="Full name"
+                  required
+                >
+                  <Input
+                    autoComplete="name"
+                    onBlur={field.handleBlur}
+                    onChange={(event) => {
+                      setFieldErrors((current) =>
+                        clearFieldError(current, "name"),
+                      );
+                      setFormError(null);
+                      field.handleChange(event.target.value);
+                    }}
+                    placeholder="Padel Organizer"
+                    value={field.state.value}
+                  />
+                </Field>
+              )}
+            </form.Field>
+
+            <form.Field name="email">
+              {(field) => (
+                <Field
+                  description="This becomes your sign-in identifier."
+                  error={fieldErrors.email}
+                  label="Email"
+                  required
+                >
+                  <Input
+                    autoComplete="email"
+                    onBlur={field.handleBlur}
+                    onChange={(event) => {
+                      setFieldErrors((current) =>
+                        clearFieldError(current, "email"),
+                      );
+                      setFormError(null);
+                      field.handleChange(event.target.value);
+                    }}
+                    placeholder="organizer@example.com"
+                    type="email"
+                    value={field.state.value}
+                  />
+                </Field>
+              )}
+            </form.Field>
+
+            <form.Field name="password">
+              {(field) => (
+                <Field
+                  description="Use at least eight characters for the initial credential flow."
+                  error={fieldErrors.password}
+                  label="Password"
+                  required
+                >
+                  <Input
+                    autoComplete="new-password"
+                    onBlur={field.handleBlur}
+                    onChange={(event) => {
+                      setFieldErrors((current) =>
+                        clearFieldError(current, "password"),
+                      );
+                      setFormError(null);
+                      field.handleChange(event.target.value);
+                    }}
+                    placeholder="Create a strong password"
+                    type="password"
+                    value={field.state.value}
+                  />
+                </Field>
+              )}
+            </form.Field>
+
+            <div className="grid gap-3 pt-1">
+              <Button disabled={signUpMutation.isPending} type="submit">
+                {signUpMutation.isPending
+                  ? "Creating account..."
+                  : "Create account"}
+              </Button>
+              <p className="text-sm leading-6 text-muted-foreground">
+                Already have an account?{" "}
+                <Link
+                  className="font-medium text-primary underline-offset-4 hover:underline"
+                  to="/login"
+                >
+                  Sign in instead
+                </Link>
+                .
+              </p>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </AuthFrame>
+  );
+}
+
+function DashboardPage() {
+  const navigate = useNavigate();
+  const { apiClient, queryClient } = readRouterContext();
+  const sessionQuery = useQuery(getSessionQueryOptions(apiClient));
+  const [signOutError, setSignOutError] = useState<string | null>(null);
+
+  const signOutMutation = useMutation({
+    mutationFn: () => apiClient.signOut(),
+    onError: (error) => {
+      setSignOutError(
+        getAuthErrorMessage(
+          error,
+          "We could not end the session right now. Please try again.",
+        ),
+      );
+    },
+    onSuccess: async () => {
+      setSignOutError(null);
+      queryClient.setQueryData(
+        getSessionQueryOptions(apiClient).queryKey,
+        null,
+      );
+      queryClient.removeQueries({
+        exact: true,
+        queryKey: authFlashMessageQueryKey,
+      });
+      startTransition(() => {
+        void navigate({ to: "/login" });
+      });
+    },
+  });
+
+  const flashMessage = queryClient.getQueryData<string>(
+    authFlashMessageQueryKey,
+  );
+  const currentSession = sessionQuery.data;
+
+  if (!currentSession) {
+    return null;
+  }
+
+  return (
+    <main className="min-h-screen bg-[linear-gradient(180deg,_rgba(14,165,233,0.08),_transparent_18%),linear-gradient(180deg,_#f8fafc,_hsl(var(--background)))] px-6 py-12 text-foreground">
+      <div className="mx-auto grid max-w-5xl gap-6">
+        {flashMessage ? (
+          <InlineAlert variant="success">
+            <InlineAlertTitle variant="success">
+              Authenticated session established
+            </InlineAlertTitle>
+            <InlineAlertDescription>{flashMessage}</InlineAlertDescription>
+          </InlineAlert>
+        ) : null}
+
+        {signOutError ? (
+          <InlineAlert variant="blocked">
+            <InlineAlertTitle variant="blocked">
+              Sign-out could not complete
+            </InlineAlertTitle>
+            <InlineAlertDescription>{signOutError}</InlineAlertDescription>
+          </InlineAlert>
+        ) : null}
+
+        <Card className="border-border/80 bg-background/95 shadow-xl shadow-slate-950/5">
+          <CardHeader className="gap-3">
+            <p className="text-sm font-medium uppercase tracking-[0.2em] text-primary">
+              Authenticated workspace
+            </p>
+            <CardTitle className="text-3xl">
+              Welcome, {currentSession.user.name}.
+            </CardTitle>
+            <CardDescription className="max-w-2xl text-base leading-7">
+              You are now inside the first post-login landing surface for the
+              product. This route confirms the guest-only entry screens are
+              behind you and the Better Auth session is active for future
+              protected workflows.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-6">
+            <div className="grid gap-3 rounded-2xl border border-border/80 bg-slate-50/80 p-5 text-sm">
+              <p>
+                <span className="font-medium">Signed in as:</span>{" "}
+                {currentSession.user.email}
+              </p>
+              <p>
+                <span className="font-medium">Session expires:</span>{" "}
+                {new Date(currentSession.session.expiresAt).toLocaleString()}
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Button
+                disabled={signOutMutation.isPending}
+                onClick={() => {
+                  void signOutMutation.mutateAsync();
+                }}
+              >
+                {signOutMutation.isPending ? "Signing out..." : "Sign out"}
+              </Button>
+              <Button asChild variant="outline">
+                <Link to="/login">Return to sign-in</Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}
+
+const rootRoute = createRootRouteWithContext<AppRouterContext>()({
+  component: AuthLayout,
+});
+
+const indexRoute = createRoute({
+  beforeLoad: async ({ context }) => {
+    const session = await context.queryClient.ensureQueryData(
+      getSessionQueryOptions(context.apiClient),
+    );
+
+    throw redirect({
+      to: session ? "/dashboard" : "/login",
+    });
+  },
+  getParentRoute: () => rootRoute,
+  path: "/",
+});
+
+const loginRoute = createRoute({
+  beforeLoad: async ({ context }) => {
+    const session = await context.queryClient.ensureQueryData(
+      getSessionQueryOptions(context.apiClient),
+    );
+
+    if (session) {
+      throw redirect({
+        to: "/dashboard",
+      });
+    }
+  },
+  component: LoginPage,
+  getParentRoute: () => rootRoute,
+  path: "/login",
+});
+
+const registerRoute = createRoute({
+  beforeLoad: async ({ context }) => {
+    const session = await context.queryClient.ensureQueryData(
+      getSessionQueryOptions(context.apiClient),
+    );
+
+    if (session) {
+      throw redirect({
+        to: "/dashboard",
+      });
+    }
+  },
+  component: RegisterPage,
+  getParentRoute: () => rootRoute,
+  path: "/register",
+});
+
+const dashboardRoute = createRoute({
+  beforeLoad: async ({ context }) => {
+    const session = await context.queryClient.ensureQueryData(
+      getSessionQueryOptions(context.apiClient),
+    );
+
+    if (!session) {
+      throw redirect({
+        to: "/login",
+      });
+    }
+  },
+  component: DashboardPage,
+  getParentRoute: () => rootRoute,
+  path: "/dashboard",
+});
+
+const routeTree = rootRoute.addChildren([
+  indexRoute,
+  loginRoute,
+  registerRoute,
+  dashboardRoute,
+]);
+
+export function createAppRouter(
+  context: AppRouterContext,
+  options?: {
+    history?: RouterHistory;
+  },
+) {
+  return createRouter({
+    context,
+    defaultPendingMs: 0,
+    routeTree,
+    ...(options?.history ? { history: options.history } : {}),
+  });
+}
+
+export type AppRouter = ReturnType<typeof createAppRouter>;
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: AppRouter;
+  }
+}

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -138,7 +138,6 @@ function LoginPage() {
     defaultValues: {
       email: "",
       password: "",
-      rememberMe: true,
     } satisfies SignInEmailRequest,
     onSubmit: async ({ value }) => {
       const parsed = signInEmailRequestSchema.safeParse(value);
@@ -303,7 +302,6 @@ function RegisterPage() {
       email: "",
       name: "",
       password: "",
-      rememberMe: true,
     } satisfies SignUpEmailRequest,
     onSubmit: async ({ value }) => {
       const parsed = signUpEmailRequestSchema.safeParse(value);
@@ -493,9 +491,9 @@ function DashboardPage() {
     },
   });
 
-  const flashMessage = queryClient.getQueryData<string>(
-    authFlashMessageQueryKey,
-  );
+  const flashMessage = queryClient.getQueryData(authFlashMessageQueryKey) as
+    | string
+    | undefined;
   const currentSession = sessionQuery.data;
 
   if (!currentSession) {
@@ -661,9 +659,3 @@ export function createAppRouter(
 }
 
 export type AppRouter = ReturnType<typeof createAppRouter>;
-
-declare module "@tanstack/react-router" {
-  interface Register {
-    router: AppRouter;
-  }
-}

--- a/apps/web/test/auth-routes.test.tsx
+++ b/apps/web/test/auth-routes.test.tsx
@@ -62,6 +62,7 @@ function createApiClientMock(
   overrides: Partial<PadelApiClient> = {},
 ): PadelApiClient {
   return {
+    getCompetitionOverview: vi.fn().mockResolvedValue([]),
     getCurrentSession: vi.fn().mockResolvedValue(null),
     signIn: vi.fn(),
     signOut: vi.fn().mockResolvedValue({ success: true }),
@@ -195,7 +196,6 @@ describe("auth routes", () => {
         email: "organizer@example.com",
         name: "Organizer One",
         password: "password-1234",
-        rememberMe: true,
       });
     });
   });

--- a/apps/web/test/auth-routes.test.tsx
+++ b/apps/web/test/auth-routes.test.tsx
@@ -1,10 +1,18 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
-import { userEvent } from "@testing-library/user-event";
 import { QueryClient } from "@tanstack/react-query";
 import { createMemoryHistory } from "@tanstack/react-router";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 import { ApiClientError, type PadelApiClient } from "@padel/api-client";
 

--- a/apps/web/test/auth-routes.test.tsx
+++ b/apps/web/test/auth-routes.test.tsx
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { QueryClient } from "@tanstack/react-query";
+import { createMemoryHistory } from "@tanstack/react-router";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { ApiClientError, type PadelApiClient } from "@padel/api-client";
+
+import { App, createAppRuntime } from "../src/app.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeAll(() => {
+  Object.defineProperty(window, "scrollTo", {
+    configurable: true,
+    value: vi.fn(),
+    writable: true,
+  });
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+function createSession() {
+  return {
+    session: {
+      createdAt: "2026-05-01T00:00:00.000Z",
+      expiresAt: "2026-05-10T00:00:00.000Z",
+      id: "session-1",
+      ipAddress: null,
+      token: "token-1",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+      userAgent: "vitest",
+      userId: "user-1",
+    },
+    user: {
+      createdAt: "2026-05-01T00:00:00.000Z",
+      email: "organizer@example.com",
+      emailVerified: false,
+      id: "user-1",
+      image: null,
+      name: "Organizer One",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+    },
+  } as const;
+}
+
+function createApiClientMock(
+  overrides: Partial<PadelApiClient> = {},
+): PadelApiClient {
+  return {
+    getCurrentSession: vi.fn().mockResolvedValue(null),
+    signIn: vi.fn(),
+    signOut: vi.fn().mockResolvedValue({ success: true }),
+    signUp: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderWithRuntime(
+  apiClient: PadelApiClient,
+  initialEntries: string[],
+) {
+  const runtime = createAppRuntime({
+    apiClient,
+    history: createMemoryHistory({ initialEntries }),
+    queryClient: new QueryClient({
+      defaultOptions: {
+        mutations: {
+          retry: false,
+        },
+        queries: {
+          retry: false,
+        },
+      },
+    }),
+  });
+
+  render(<App runtime={runtime} />);
+
+  return runtime;
+}
+
+describe("auth routes", () => {
+  it("redirects authenticated users away from guest-only entry routes", async () => {
+    const apiClient = createApiClientMock({
+      getCurrentSession: vi.fn().mockResolvedValue(createSession()),
+    });
+
+    renderWithRuntime(apiClient, ["/login"]);
+
+    await screen.findByRole("heading", {
+      name: "Welcome, Organizer One.",
+    });
+
+    expect(screen.queryByRole("heading", { name: "Sign in" })).toBeNull();
+  });
+
+  it("shows pending and error states when sign-in fails", async () => {
+    let rejectSignIn!: (reason?: unknown) => void;
+
+    const signInPromise = new Promise<never>((_, reject) => {
+      rejectSignIn = reject;
+    });
+
+    const apiClient = createApiClientMock({
+      getCurrentSession: vi.fn().mockResolvedValue(null),
+      signIn: vi.fn().mockReturnValue(signInPromise),
+    });
+
+    renderWithRuntime(apiClient, ["/login"]);
+
+    await screen.findByRole("heading", { name: "Sign in" });
+
+    const user = userEvent.setup();
+
+    await user.type(
+      screen.getByRole("textbox", { name: /email/i }),
+      "organizer@example.com",
+    );
+    await user.type(screen.getByLabelText(/password/i), "password-1234");
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+    const pendingButton = screen.getByRole("button", {
+      name: "Signing in...",
+    });
+
+    expect((pendingButton as HTMLButtonElement).disabled).toBe(true);
+
+    rejectSignIn(
+      new ApiClientError(
+        "Email or password is incorrect.",
+        401,
+        "INVALID_EMAIL_OR_PASSWORD",
+      ),
+    );
+
+    await screen.findByText("Email or password is incorrect.");
+  });
+
+  it("registers a user and lands them on the dashboard with a success message", async () => {
+    const apiClient = createApiClientMock({
+      getCurrentSession: vi
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(createSession()),
+      signUp: vi.fn().mockResolvedValue({
+        token: null,
+        user: createSession().user,
+      }),
+    });
+
+    renderWithRuntime(apiClient, ["/register"]);
+
+    await screen.findByRole("heading", { name: "Register" });
+
+    const user = userEvent.setup();
+
+    await user.type(
+      screen.getByRole("textbox", { name: /full name/i }),
+      "Organizer One",
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: /email/i }),
+      "organizer@example.com",
+    );
+    await user.type(screen.getByLabelText(/password/i), "password-1234");
+    await user.click(screen.getByRole("button", { name: "Create account" }));
+
+    await screen.findByRole("heading", {
+      name: "Welcome, Organizer One.",
+    });
+
+    expect(
+      screen.getByText(
+        "Account created successfully. Your authenticated dashboard is ready.",
+      ),
+    ).not.toBeNull();
+
+    await waitFor(() => {
+      expect(apiClient.signUp).toHaveBeenCalledWith({
+        email: "organizer@example.com",
+        name: "Organizer One",
+        password: "password-1234",
+        rememberMe: true,
+      });
+    });
+  });
+});

--- a/apps/web/test/contracts.test.ts
+++ b/apps/web/test/contracts.test.ts
@@ -1,9 +1,0 @@
-import { describe, expect, it } from "vitest";
-
-import { getWebContractVersion } from "../src/contracts.js";
-
-describe("web shared schema wiring", () => {
-  it("consumes the shared schema package", () => {
-    expect(getWebContractVersion()).toBe("0.0.0");
-  });
-});

--- a/docs/09-agile/product-backlog.md
+++ b/docs/09-agile/product-backlog.md
@@ -619,3 +619,41 @@ For each ticket, include:
 - GitHub labels: `type:task`, `lane:frontend`, `area:ui-package`, `area:storybook`, `target:packages-ui`, `target:packages-config`
 - milestone/sprint: `next-ui-package-sprint`
 - GitHub issue URL or placeholder: `https://github.com/Damimd10/padel/issues/32`
+
+### TKT-042 - Build frontend login and registration routes on top of the backend auth contracts
+
+- ID: `TKT-042`
+- type: `task`
+- epic: `authentication-self-service`
+- delivery lane: `frontend`
+- affected apps/packages: `apps/web`, `packages/api-client`, `packages/ui`
+- title: `Build frontend login and registration routes on top of the backend auth contracts`
+- story/task description: Introduce the first user-facing authentication entry flows in `apps/web` by building login and registration screens on top of the backend contracts from the backend self-service auth slice. The scope should add typed auth client wrappers in `packages/api-client`, guest-only frontend route behavior, and validated form handling that composes existing shared `packages/ui` primitives without pushing auth-specific mutation logic into the UI package.
+- acceptance criteria:
+  - `packages/api-client` exposes typed client helpers or wrappers for the sign-up, sign-in, sign-out, and current-session contracts from `packages/schemas`
+  - `apps/web` includes login and registration routes with validated form handling and clear success, error, and pending states
+  - authenticated users are redirected away from guest-only entry routes and the flow preserves a credible post-login landing behavior
+  - the implementation uses shared `packages/ui` components without embedding auth-specific mutation logic into the UI package
+  - tests validate contract mapping, route behavior, and user-visible form-state handling
+  - forgot-password and reset-password flows remain out of scope for this ticket
+- linked docs:
+  - `/docs/12-frontend-architecture/routing.md`
+  - `/docs/12-frontend-architecture/forms-and-validation.md`
+  - `/docs/12-frontend-architecture/server-state.md`
+  - `/docs/12-frontend-architecture/frontend-overview.md`
+  - `/docs/16-backend-architecture/security-strategy.md`
+- linked ADRs:
+  - `/docs/07-adrs/adr-001-frontend-data-loading-and-contract-coordination.md`
+  - `/docs/07-adrs/adr-002-frontend-architecture.md`
+  - `/docs/07-adrs/adr-009-testing-stack.md`
+  - `/docs/07-adrs/adr-011-authentication-strategy.md`
+- testing expectations:
+  - unit: cover form-state handling, contract mapping, and guest-only redirect decisions
+  - integration: verify the route layer composes typed auth clients with shared UI primitives without package-boundary leaks
+  - e2e/manual: confirm a user can register and then sign in through the real frontend flow once the backend contracts are available
+- estimate: `M`
+- status: `in-sprint`
+- implementation workflow: `frontend`
+- GitHub labels: `type:task`, `lane:frontend`, `area:frontend`, `area:platform`, `target:apps-web`, `target:packages-api-client`, `target:packages-ui`
+- milestone/sprint: `auth-self-service-foundation-sprint`
+- GitHub issue URL or placeholder: `https://github.com/Damimd10/padel/issues/42`

--- a/docs/09-agile/sprint-backlog.md
+++ b/docs/09-agile/sprint-backlog.md
@@ -29,6 +29,7 @@ If this document and the GitHub Project disagree, update both and record the rea
 - `TKT-017` remains the next available backend slice, but it is not part of the current frontend-focused sprint snapshot.
 - `TKT-018`, `TKT-019`, `TKT-020`, and `TKT-021` are treated as delivered shared UI foundation work that enables the next input-focused wave.
 - `TKT-029` is now the active planned frontend sprint item for `next-ui-package-sprint`.
+- `TKT-042` is now in active delivery for `auth-self-service-foundation-sprint`, with GitHub issue `#42` moved into project status `In Progress` while the frontend auth routes and typed client wrappers are implemented.
 
 ## Active Sprint Record
 
@@ -40,3 +41,12 @@ If this document and the GitHub Project disagree, update both and record the rea
 - current project status: `In Sprint`
 - blocked/unblocked state: `unblocked`
 - notes for carryover risk: `none; GitHub issue metadata, project status, and sprint docs are aligned for implementation`
+
+- ticket ID and title: `TKT-042` - Build frontend login and registration routes on top of the backend auth contracts
+- delivery lane: `frontend`
+- affected apps/packages: `apps/web`, `packages/api-client`, `packages/ui`
+- owner: `codex`
+- GitHub issue link: `https://github.com/Damimd10/padel/issues/42`
+- current project status: `In Progress`
+- blocked/unblocked state: `unblocked`
+- notes for carryover risk: `depends on the backend self-service auth contract hardening ticket for final schema ownership convergence, but the current Better Auth endpoints already allow the frontend route and typed client slice to move forward`

--- a/docs/09-agile/sprint-plan.md
+++ b/docs/09-agile/sprint-plan.md
@@ -63,3 +63,34 @@ Every committed ticket must:
   - the shipped APIs remain generic and compose with `Field` without feature-specific parsing or submission logic
   - Storybook documents invalid, disabled, read-only, and keyboard-relevant states clearly enough for competition-configuration and result-entry forms
   - GitHub execution state stays synced so the sprint doc, issue metadata, and project board all reflect the same committed and planned work
+
+## Supplemental Sprint Snapshot
+
+- sprint goal: deliver the first user-facing self-service authentication entry flow so the web app has real login, registration, guest-only routing, and a credible post-login landing path on top of the Better Auth backend surface
+- sprint dates or iteration label: `auth-self-service-foundation-sprint`
+- capacity assumptions:
+  - the Better Auth backend foundation is already delivered and running through `apps/api`
+  - frontend implementation can begin against the live Better Auth session endpoints while backend contract hardening continues in parallel
+  - this slice should stay focused on sign-up, sign-in, sign-out, current-session handling, and guest-only route behavior
+- committed tickets:
+  - `TKT-042` - build frontend login and registration routes on top of the backend auth contracts
+- stretch tickets:
+  - `TKT-043` - expose backend sign-up, sign-in, sign-out, and session contracts for self-service auth
+- lane balance across frontend / backend / infrastructure:
+  - frontend: `TKT-042` is the active implementation slice for authenticated entry and landing behavior
+  - backend: `TKT-043` remains the contract-hardening companion ticket for explicit schema ownership and auth error mapping
+  - infrastructure: no additional sprint-critical infrastructure work is required beyond the already delivered local PostgreSQL and Better Auth foundation
+- affected apps/packages summary:
+  - `TKT-042`: `apps/web`, `packages/api-client`, `packages/ui`
+  - `TKT-043`: `apps/api`, `packages/schemas`
+- dependencies and blockers:
+  - `TKT-042` depends on the delivered Better Auth runtime from `TKT-016` and can scaffold the frontend route layer before `TKT-043` is fully complete
+  - the frontend slice must keep auth-specific mutation logic in `apps/web` and `packages/api-client`, not in `packages/ui`
+  - final long-term ownership of the auth transport contracts should converge with `TKT-043` once the backend companion slice is complete
+- GitHub milestone / project view used for execution:
+  - milestone: `auth-self-service-foundation-sprint`
+  - project status: issue `#42` is represented in `Padel Delivery` as `In Progress`
+- exit criteria:
+  - `TKT-042` lands with typed auth client wrappers, login and registration routes, guest-only redirect behavior, and tests for route and form-state handling
+  - authenticated users reach a credible post-login landing route rather than remaining on guest-only entry screens
+  - the sprint doc, issue metadata, and GitHub project status remain aligned throughout delivery

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@padel/schemas": "workspace:*",
+    "axios": "^1.13.2",
     "zod": "^4.3.6"
   },
   "main": "./dist/index.js",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@padel/schemas": "workspace:*"
+    "@padel/schemas": "workspace:*",
+    "zod": "^4.3.6"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,3 +1,4 @@
+import axios, { AxiosError, type AxiosInstance } from "axios";
 import {
   type CompetitionOverviewCollection,
   type CurrentSessionResponse,
@@ -40,8 +41,8 @@ export interface CompetitionOverviewRequestOptions {
 
 export interface ApiClientConfig {
   apiBaseUrl?: string;
+  axios?: AxiosInstance;
   baseUrl?: string;
-  fetch?: typeof globalThis.fetch;
 }
 
 export class ApiClientError extends Error {
@@ -79,120 +80,112 @@ function resolveBaseUrl(config: ApiClientConfig) {
   return normalizeBaseUrl(config.baseUrl ?? config.apiBaseUrl);
 }
 
-async function readJson(response: Response) {
-  const text = await response.text();
-
-  if (!text) {
-    return {
-      payload: null,
-      rawBody: "",
-    };
+function serializePayload(payload: unknown) {
+  if (typeof payload === "string") {
+    return payload;
   }
 
-  return {
-    payload: JSON.parse(text) as unknown,
-    rawBody: text,
-  };
+  if (payload === undefined) {
+    return undefined;
+  }
+
+  try {
+    return JSON.stringify(payload);
+  } catch {
+    return undefined;
+  }
 }
 
-async function parseJsonResponse<T>(
-  response: Response,
-  schema: z.ZodType<T>,
-): Promise<T> {
-  const { payload, rawBody } = await readJson(response);
+function mapAxiosError(error: unknown): ApiClientError {
+  if (error instanceof ApiClientError) {
+    return error;
+  }
 
-  if (!response.ok) {
+  if (error instanceof AxiosError) {
+    const payload = error.response?.data;
     const parsedError = authErrorPayloadSchema.safeParse(payload);
 
-    throw new ApiClientError(
+    return new ApiClientError(
       parsedError.success && parsedError.data.message
         ? parsedError.data.message
-        : `Request failed with status ${response.status}.`,
-      response.status,
+        : error.message,
+      error.response?.status ?? 500,
       parsedError.success ? parsedError.data.code : undefined,
       payload,
-      rawBody,
+      serializePayload(payload),
     );
   }
 
-  return schema.parse(payload);
+  if (error instanceof Error) {
+    return new ApiClientError(error.message, 500);
+  }
+
+  return new ApiClientError("Unknown API client error.", 500);
 }
 
-function buildUrl(baseUrl: string, path: string) {
-  return `${baseUrl}${path}`;
+async function parseAxiosResponse<T>(
+  request: Promise<{ data: unknown }>,
+  schema: z.ZodType<T>,
+): Promise<T> {
+  try {
+    const response = await request;
+    return schema.parse(response.data);
+  } catch (error) {
+    throw mapAxiosError(error);
+  }
 }
 
 export function createApiClient(config: ApiClientConfig = {}): PadelApiClient {
-  const request = config.fetch ?? globalThis.fetch;
-  const baseUrl = resolveBaseUrl(config);
-
-  if (!request) {
-    throw new Error(
-      "A fetch implementation is required to create the API client.",
-    );
-  }
+  const api =
+    config.axios ??
+    axios.create({
+      baseURL: resolveBaseUrl(config),
+      headers: {
+        "Content-Type": "application/json",
+      },
+      withCredentials: true,
+    });
 
   return {
     async signUp(input) {
       const payload = signUpEmailRequestSchema.parse(input);
-      const response = await request(buildUrl(baseUrl, "/auth/sign-up"), {
-        body: JSON.stringify(payload),
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        method: "POST",
-      });
 
-      return parseJsonResponse(response, signUpEmailResponseSchema);
+      return parseAxiosResponse(
+        api.post("/auth/sign-up", payload),
+        signUpEmailResponseSchema,
+      );
     },
 
     async signIn(input) {
       const payload = signInEmailRequestSchema.parse(input);
-      const response = await request(buildUrl(baseUrl, "/auth/sign-in"), {
-        body: JSON.stringify(payload),
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        method: "POST",
-      });
 
-      return parseJsonResponse(response, signInEmailResponseSchema);
+      return parseAxiosResponse(
+        api.post("/auth/sign-in", payload),
+        signInEmailResponseSchema,
+      );
     },
 
     async signOut() {
-      const response = await request(buildUrl(baseUrl, "/auth/sign-out"), {
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        method: "POST",
-      });
-
-      return parseJsonResponse(response, signOutResponseSchema);
+      return parseAxiosResponse(api.post("/auth/sign-out"), signOutResponseSchema);
     },
 
     async getCurrentSession() {
-      const response = await request(buildUrl(baseUrl, "/auth/session"), {
-        credentials: "include",
-        method: "GET",
-      });
-
-      return parseJsonResponse(response, currentSessionResponseSchema);
+      return parseAxiosResponse(
+        api.get("/auth/session"),
+        currentSessionResponseSchema,
+      );
     },
 
     async getCompetitionOverview(options = {}) {
-      const response = await request(buildUrl(baseUrl, competitionOverviewPath), {
-        credentials: "include",
-        headers: {
-          accept: "application/json",
-        },
-        method: "GET",
-        signal: options.signal,
-      });
-
-      return parseJsonResponse(response, competitionOverviewCollectionSchema);
+      return parseAxiosResponse(
+        api.get(competitionOverviewPath, {
+          headers: {
+            accept: "application/json",
+          },
+          signal: options.signal,
+        }),
+        competitionOverviewCollectionSchema,
+      );
     },
   };
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,10 +1,32 @@
 import {
   type CompetitionOverviewCollection,
+  type CurrentSessionResponse,
+  type SignInEmailRequest,
+  type SignInEmailResponse,
+  type SignOutResponse,
+  type SignUpEmailRequest,
+  type SignUpEmailResponse,
   competitionOverviewCollectionSchema,
+  currentSessionResponseSchema,
   sharedPingContract,
+  signInEmailRequestSchema,
+  signInEmailResponseSchema,
+  signOutResponseSchema,
+  signUpEmailRequestSchema,
+  signUpEmailResponseSchema,
 } from "@padel/schemas";
+import { z } from "zod";
 
 export const competitionOverviewPath = "/competitions";
+
+const authErrorPayloadSchema = z
+  .object({
+    code: z.string().optional(),
+    message: z.string().optional(),
+  })
+  .passthrough();
+
+export type AuthErrorPayload = z.infer<typeof authErrorPayloadSchema>;
 
 export function sampleContractSummary() {
   const parsed = sharedPingContract.parse({ status: "ok", version: "0.0.0" });
@@ -12,82 +34,165 @@ export function sampleContractSummary() {
   return `${parsed.status}:${parsed.version}`;
 }
 
+export interface CompetitionOverviewRequestOptions {
+  signal?: AbortSignal;
+}
+
+export interface ApiClientConfig {
+  apiBaseUrl?: string;
+  baseUrl?: string;
+  fetch?: typeof globalThis.fetch;
+}
+
 export class ApiClientError extends Error {
   constructor(
     message: string,
     readonly status: number,
-    readonly responseBody: string,
+    readonly code?: string,
+    readonly payload?: unknown,
+    readonly responseBody?: string,
   ) {
     super(message);
     this.name = "ApiClientError";
   }
 }
 
-export interface CompetitionOverviewRequestOptions {
-  signal?: AbortSignal;
-}
-
-export interface CreateApiClientOptions {
-  apiBaseUrl?: string;
-  fetch?: typeof globalThis.fetch;
-}
-
 export interface PadelApiClient {
   getCompetitionOverview(
     options?: CompetitionOverviewRequestOptions,
   ): Promise<CompetitionOverviewCollection>;
+  getCurrentSession(): Promise<CurrentSessionResponse>;
+  signIn(input: SignInEmailRequest): Promise<SignInEmailResponse>;
+  signOut(): Promise<SignOutResponse>;
+  signUp(input: SignUpEmailRequest): Promise<SignUpEmailResponse>;
 }
 
-function buildApiUrl(apiBaseUrl: string, path: string) {
-  const normalizedBaseUrl = apiBaseUrl.endsWith("/")
-    ? apiBaseUrl.slice(0, -1)
-    : apiBaseUrl;
+function normalizeBaseUrl(baseUrl?: string) {
+  if (!baseUrl) {
+    return "";
+  }
 
-  return `${normalizedBaseUrl}${path}`;
+  return baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
 }
 
-async function parseJsonWithSchema<T>(
+function resolveBaseUrl(config: ApiClientConfig) {
+  return normalizeBaseUrl(config.baseUrl ?? config.apiBaseUrl);
+}
+
+async function readJson(response: Response) {
+  const text = await response.text();
+
+  if (!text) {
+    return {
+      payload: null,
+      rawBody: "",
+    };
+  }
+
+  return {
+    payload: JSON.parse(text) as unknown,
+    rawBody: text,
+  };
+}
+
+async function parseJsonResponse<T>(
   response: Response,
-  schema: { parse(input: unknown): T },
+  schema: z.ZodType<T>,
 ): Promise<T> {
-  const rawBody = await response.text();
+  const { payload, rawBody } = await readJson(response);
 
   if (!response.ok) {
+    const parsedError = authErrorPayloadSchema.safeParse(payload);
+
     throw new ApiClientError(
-      `API request failed with status ${response.status}.`,
+      parsedError.success && parsedError.data.message
+        ? parsedError.data.message
+        : `Request failed with status ${response.status}.`,
       response.status,
+      parsedError.success ? parsedError.data.code : undefined,
+      payload,
       rawBody,
     );
   }
 
-  return schema.parse(JSON.parse(rawBody) as unknown);
+  return schema.parse(payload);
 }
 
-export function createApiClient({
-  apiBaseUrl = "/api",
-  fetch = globalThis.fetch,
-}: CreateApiClientOptions = {}): PadelApiClient {
-  if (!fetch) {
+function buildUrl(baseUrl: string, path: string) {
+  return `${baseUrl}${path}`;
+}
+
+export function createApiClient(config: ApiClientConfig = {}): PadelApiClient {
+  const request = config.fetch ?? globalThis.fetch;
+  const baseUrl = resolveBaseUrl(config);
+
+  if (!request) {
     throw new Error(
       "A fetch implementation is required to create the API client.",
     );
   }
 
   return {
-    async getCompetitionOverview(options = {}) {
-      const response = await fetch(
-        buildApiUrl(apiBaseUrl, competitionOverviewPath),
-        {
-          credentials: "include",
-          headers: {
-            accept: "application/json",
-          },
-          method: "GET",
-          signal: options.signal,
+    async signUp(input) {
+      const payload = signUpEmailRequestSchema.parse(input);
+      const response = await request(buildUrl(baseUrl, "/auth/sign-up"), {
+        body: JSON.stringify(payload),
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
         },
-      );
+        method: "POST",
+      });
 
-      return parseJsonWithSchema(response, competitionOverviewCollectionSchema);
+      return parseJsonResponse(response, signUpEmailResponseSchema);
+    },
+
+    async signIn(input) {
+      const payload = signInEmailRequestSchema.parse(input);
+      const response = await request(buildUrl(baseUrl, "/auth/sign-in"), {
+        body: JSON.stringify(payload),
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      });
+
+      return parseJsonResponse(response, signInEmailResponseSchema);
+    },
+
+    async signOut() {
+      const response = await request(buildUrl(baseUrl, "/auth/sign-out"), {
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      });
+
+      return parseJsonResponse(response, signOutResponseSchema);
+    },
+
+    async getCurrentSession() {
+      const response = await request(buildUrl(baseUrl, "/auth/session"), {
+        credentials: "include",
+        method: "GET",
+      });
+
+      return parseJsonResponse(response, currentSessionResponseSchema);
+    },
+
+    async getCompetitionOverview(options = {}) {
+      const response = await request(buildUrl(baseUrl, competitionOverviewPath), {
+        credentials: "include",
+        headers: {
+          accept: "application/json",
+        },
+        method: "GET",
+        signal: options.signal,
+      });
+
+      return parseJsonResponse(response, competitionOverviewCollectionSchema);
     },
   };
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,4 +1,3 @@
-import axios, { AxiosError, type AxiosInstance } from "axios";
 import {
   type CompetitionOverviewCollection,
   type CurrentSessionResponse,
@@ -16,6 +15,7 @@ import {
   signUpEmailRequestSchema,
   signUpEmailResponseSchema,
 } from "@padel/schemas";
+import axios, { AxiosError, type AxiosInstance } from "axios";
 import { z } from "zod";
 
 export const competitionOverviewPath = "/competitions";
@@ -43,6 +43,7 @@ export interface ApiClientConfig {
   apiBaseUrl?: string;
   axios?: AxiosInstance;
   baseUrl?: string;
+  fetch?: typeof globalThis.fetch;
 }
 
 export class ApiClientError extends Error {
@@ -78,6 +79,22 @@ function normalizeBaseUrl(baseUrl?: string) {
 
 function resolveBaseUrl(config: ApiClientConfig) {
   return normalizeBaseUrl(config.baseUrl ?? config.apiBaseUrl);
+}
+
+async function readJson(response: Response) {
+  const rawBody = await response.text();
+
+  if (!rawBody) {
+    return {
+      payload: null,
+      rawBody,
+    };
+  }
+
+  return {
+    payload: JSON.parse(rawBody) as unknown,
+    rawBody,
+  };
 }
 
 function serializePayload(payload: unknown) {
@@ -135,16 +152,75 @@ async function parseAxiosResponse<T>(
   }
 }
 
+function createFetchTransport(
+  fetchImplementation: typeof globalThis.fetch,
+  baseUrl: string,
+) {
+  async function request(
+    path: string,
+    init: RequestInit & {
+      headers?: Record<string, string>;
+    } = {},
+  ) {
+    const response = await fetchImplementation(`${baseUrl}${path}`, {
+      credentials: "include",
+      ...init,
+    });
+    const { payload, rawBody } = await readJson(response);
+
+    if (!response.ok) {
+      const parsedError = authErrorPayloadSchema.safeParse(payload);
+
+      throw new ApiClientError(
+        parsedError.success && parsedError.data.message
+          ? parsedError.data.message
+          : `Request failed with status ${response.status}.`,
+        response.status,
+        parsedError.success ? parsedError.data.code : undefined,
+        payload,
+        rawBody,
+      );
+    }
+
+    return { data: payload };
+  }
+
+  return {
+    get(
+      path: string,
+      config?: { headers?: Record<string, string>; signal?: AbortSignal },
+    ) {
+      return request(path, {
+        headers: config?.headers,
+        method: "GET",
+        signal: config?.signal,
+      });
+    },
+    post(path: string, data?: unknown) {
+      return request(path, {
+        body: data === undefined ? undefined : JSON.stringify(data),
+        headers: {
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      });
+    },
+  };
+}
+
 export function createApiClient(config: ApiClientConfig = {}): PadelApiClient {
+  const baseUrl = resolveBaseUrl(config);
   const api =
     config.axios ??
-    axios.create({
-      baseURL: resolveBaseUrl(config),
-      headers: {
-        "Content-Type": "application/json",
-      },
-      withCredentials: true,
-    });
+    (config.fetch
+      ? createFetchTransport(config.fetch, baseUrl)
+      : axios.create({
+          baseURL: baseUrl,
+          headers: {
+            "Content-Type": "application/json",
+          },
+          withCredentials: true,
+        }));
 
   return {
     async signUp(input) {
@@ -166,7 +242,10 @@ export function createApiClient(config: ApiClientConfig = {}): PadelApiClient {
     },
 
     async signOut() {
-      return parseAxiosResponse(api.post("/auth/sign-out"), signOutResponseSchema);
+      return parseAxiosResponse(
+        api.post("/auth/sign-out"),
+        signOutResponseSchema,
+      );
     },
 
     async getCurrentSession() {

--- a/packages/api-client/test/index.test.ts
+++ b/packages/api-client/test/index.test.ts
@@ -8,7 +8,7 @@ import {
 import { describe, expect, it } from "vitest";
 
 import {
-  ApiClientError,
+  type ApiClientError,
   competitionOverviewPath,
   createApiClient,
   sampleContractSummary,
@@ -235,10 +235,10 @@ describe("api-client package", () => {
 
     await expect(apiClient.getCompetitionOverview()).rejects.toEqual(
       expect.objectContaining<ApiClientError>({
-        message: "Request failed with status code 503",
+        message: "Backend unavailable",
         responseBody: '{"message":"Backend unavailable"}',
         status: 503,
       }),
     );
   });
-}
+});

--- a/packages/api-client/test/index.test.ts
+++ b/packages/api-client/test/index.test.ts
@@ -168,7 +168,7 @@ describe("api-client package", () => {
     const apiClient = createApiClient({
       axios: {
         defaults: {},
-        get: async (url, config) => {
+        get: async (url: string, config?: AxiosRequestConfig) => {
           expect(url).toBe(competitionOverviewPath);
           expect(config).toMatchObject({
             headers: {
@@ -234,8 +234,9 @@ describe("api-client package", () => {
     });
 
     await expect(apiClient.getCompetitionOverview()).rejects.toEqual(
-      expect.objectContaining<ApiClientError>({
+      expect.objectContaining({
         message: "Backend unavailable",
+        name: "ApiClientError",
         responseBody: '{"message":"Backend unavailable"}',
         status: 503,
       }),

--- a/packages/api-client/test/index.test.ts
+++ b/packages/api-client/test/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import {
   ApiClientError,
   competitionOverviewPath,
@@ -9,6 +10,142 @@ import {
 describe("api-client package", () => {
   it("reads the shared schema package", () => {
     expect(sampleContractSummary()).toBe("ok:0.0.0");
+  });
+
+  it("maps the sign-up contract and sends credentials", async () => {
+    const fetchStub = async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input).toBe("http://localhost:3000/auth/sign-up");
+      expect(init?.credentials).toBe("include");
+      expect(init?.method).toBe("POST");
+      expect(init?.headers).toEqual({
+        "Content-Type": "application/json",
+      });
+      expect(JSON.parse(String(init?.body))).toEqual({
+        email: "player@example.com",
+        name: "Padel Player",
+        password: "password-1234",
+      });
+
+      return new Response(
+        JSON.stringify({
+          user: {
+            email: "player@example.com",
+            emailVerified: false,
+            id: "user-1",
+            image: null,
+            name: "Padel Player",
+          },
+        }),
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          status: 201,
+        },
+      );
+    };
+
+    const apiClient = createApiClient({
+      baseUrl: "http://localhost:3000",
+      fetch: fetchStub as typeof fetch,
+    });
+
+    await expect(
+      apiClient.signUp({
+        email: "player@example.com",
+        name: "Padel Player",
+        password: "password-1234",
+      }),
+    ).resolves.toMatchObject({
+      user: {
+        email: "player@example.com",
+        name: "Padel Player",
+      },
+    });
+  });
+
+  it("maps the current session response into a nullable frontend shape", async () => {
+    const apiClient = createApiClient({
+      fetch: async () =>
+        new Response(
+          JSON.stringify({
+            authenticated: true,
+            session: {
+              expiresAt: "2026-05-10T00:00:00.000Z",
+              id: "session-1",
+              userId: "user-1",
+            },
+            user: {
+              email: "player@example.com",
+              emailVerified: false,
+              id: "user-1",
+              image: null,
+              name: "Padel Player",
+            },
+          }),
+          {
+            headers: {
+              "Content-Type": "application/json",
+            },
+            status: 200,
+          },
+        ),
+    });
+
+    await expect(apiClient.getCurrentSession()).resolves.toMatchObject({
+      session: {
+        id: "session-1",
+      },
+      user: {
+        email: "player@example.com",
+      },
+    });
+  });
+
+  it("allows the current-session contract to return null", async () => {
+    const apiClient = createApiClient({
+      fetch: async () =>
+        new Response(JSON.stringify({ authenticated: false }), {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          status: 200,
+        }),
+    });
+
+    await expect(apiClient.getCurrentSession()).resolves.toBeNull();
+  });
+
+  it("maps backend auth failures into ApiClientError", async () => {
+    const apiClient = createApiClient({
+      fetch: async () =>
+        new Response(
+          JSON.stringify({
+            code: "invalid_credentials",
+            message: "Email or password is incorrect.",
+          }),
+          {
+            headers: {
+              "Content-Type": "application/json",
+            },
+            status: 401,
+          },
+        ),
+    });
+
+    await expect(
+      apiClient.signIn({
+        email: "player@example.com",
+        password: "wrong-password",
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining<ApiClientError>({
+        code: "invalid_credentials",
+        message: "Email or password is incorrect.",
+        name: "ApiClientError",
+        status: 401,
+      }),
+    );
   });
 
   it("parses the competition overview contract through the typed client", async () => {
@@ -45,8 +182,8 @@ describe("api-client package", () => {
 
     await expect(client.getCompetitionOverview()).resolves.toMatchObject([
       {
-        title: "North Circuit Masters",
         status: "open",
+        title: "North Circuit Masters",
       },
     ]);
   });
@@ -63,11 +200,11 @@ describe("api-client package", () => {
     });
 
     await expect(client.getCompetitionOverview()).rejects.toEqual(
-      new ApiClientError(
-        "API request failed with status 503.",
-        503,
-        '{"message":"Backend unavailable"}',
-      ),
+      expect.objectContaining<ApiClientError>({
+        message: "Request failed with status 503.",
+        responseBody: '{"message":"Backend unavailable"}',
+        status: 503,
+      }),
     );
   });
-});
+}

--- a/packages/api-client/test/index.test.ts
+++ b/packages/api-client/test/index.test.ts
@@ -1,4 +1,12 @@
+import {
+  AxiosError,
+  AxiosHeaders,
+  type AxiosInstance,
+  type AxiosRequestConfig,
+  type InternalAxiosRequestConfig,
+} from "axios";
 import { describe, expect, it } from "vitest";
+
 import {
   ApiClientError,
   competitionOverviewPath,
@@ -11,22 +19,22 @@ describe("api-client package", () => {
     expect(sampleContractSummary()).toBe("ok:0.0.0");
   });
 
-  it("maps the sign-up contract and sends credentials", async () => {
-    const fetchStub = async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(input).toBe("http://localhost:3000/auth/sign-up");
-      expect(init?.credentials).toBe("include");
-      expect(init?.method).toBe("POST");
-      expect(init?.headers).toEqual({
-        "Content-Type": "application/json",
-      });
-      expect(JSON.parse(String(init?.body))).toEqual({
+  it("maps the sign-up contract through axios with shared config", async () => {
+    const post = async (
+      url: string,
+      data?: unknown,
+      config?: AxiosRequestConfig,
+    ) => {
+      expect(url).toBe("/auth/sign-up");
+      expect(data).toEqual({
         email: "player@example.com",
         name: "Padel Player",
         password: "password-1234",
       });
+      expect(config).toBeUndefined();
 
-      return new Response(
-        JSON.stringify({
+      return {
+        data: {
           user: {
             email: "player@example.com",
             emailVerified: false,
@@ -34,19 +42,20 @@ describe("api-client package", () => {
             image: null,
             name: "Padel Player",
           },
-        }),
-        {
-          headers: {
-            "Content-Type": "application/json",
-          },
-          status: 201,
         },
-      );
+      };
     };
 
     const apiClient = createApiClient({
+      axios: {
+        defaults: {
+          baseURL: "http://localhost:3000",
+          withCredentials: true,
+        },
+        get: async () => ({ data: null }),
+        post,
+      } as unknown as AxiosInstance,
       baseUrl: "http://localhost:3000",
-      fetch: fetchStub as typeof fetch,
     });
 
     await expect(
@@ -65,9 +74,10 @@ describe("api-client package", () => {
 
   it("maps the current session response into a nullable frontend shape", async () => {
     const apiClient = createApiClient({
-      fetch: async () =>
-        new Response(
-          JSON.stringify({
+      axios: {
+        defaults: {},
+        get: async () => ({
+          data: {
             authenticated: true,
             session: {
               expiresAt: "2026-05-10T00:00:00.000Z",
@@ -81,14 +91,10 @@ describe("api-client package", () => {
               image: null,
               name: "Padel Player",
             },
-          }),
-          {
-            headers: {
-              "Content-Type": "application/json",
-            },
-            status: 200,
           },
-        ),
+        }),
+        post: async () => ({ data: null }),
+      } as unknown as AxiosInstance,
     });
 
     await expect(apiClient.getCurrentSession()).resolves.toMatchObject({
@@ -103,13 +109,11 @@ describe("api-client package", () => {
 
   it("allows the current-session contract to return null", async () => {
     const apiClient = createApiClient({
-      fetch: async () =>
-        new Response(JSON.stringify({ authenticated: false }), {
-          headers: {
-            "Content-Type": "application/json",
-          },
-          status: 200,
-        }),
+      axios: {
+        defaults: {},
+        get: async () => ({ data: { authenticated: false } }),
+        post: async () => ({ data: null }),
+      } as unknown as AxiosInstance,
     });
 
     await expect(apiClient.getCurrentSession()).resolves.toBeNull();
@@ -117,19 +121,30 @@ describe("api-client package", () => {
 
   it("maps backend auth failures into ApiClientError", async () => {
     const apiClient = createApiClient({
-      fetch: async () =>
-        new Response(
-          JSON.stringify({
-            code: "invalid_credentials",
-            message: "Email or password is incorrect.",
-          }),
-          {
-            headers: {
-              "Content-Type": "application/json",
+      axios: {
+        defaults: {},
+        get: async () => ({ data: null }),
+        post: async () => {
+          throw new AxiosError(
+            "Request failed with status code 401",
+            "ERR_BAD_REQUEST",
+            undefined,
+            undefined,
+            {
+              config: {
+                headers: new AxiosHeaders(),
+              } as InternalAxiosRequestConfig,
+              data: {
+                code: "invalid_credentials",
+                message: "Email or password is incorrect.",
+              },
+              headers: {},
+              status: 401,
+              statusText: "Unauthorized",
             },
-            status: 401,
-          },
-        ),
+          );
+        },
+      } as unknown as AxiosInstance,
     });
 
     await expect(
@@ -142,44 +157,48 @@ describe("api-client package", () => {
         code: "invalid_credentials",
         message: "Email or password is incorrect.",
         name: "ApiClientError",
+        responseBody:
+          '{"code":"invalid_credentials","message":"Email or password is incorrect."}',
         status: 401,
       }),
     );
   });
 
   it("parses the competition overview contract through the typed client", async () => {
-    const client = createApiClient({
-      apiBaseUrl: "https://padel.test/api",
-      fetch: async (input) => {
-        expect(input).toBe(`https://padel.test/api${competitionOverviewPath}`);
-
-        return new Response(
-          JSON.stringify([
-            {
-              id: "fa222204-b855-4fb0-b507-e169249e588e",
-              title: "North Circuit Masters",
-              format: "round-robin",
-              status: "open",
-              startsAt: "2026-05-03T12:00:00.000Z",
-              endsAt: "2026-05-05T21:00:00.000Z",
-              owner: {
-                id: "44e7eb17-a42b-4de8-bf34-2f8d78680d39",
-                name: "Lucia Perez",
-                email: "lucia@example.com",
-              },
-            },
-          ]),
-          {
+    const apiClient = createApiClient({
+      axios: {
+        defaults: {},
+        get: async (url, config) => {
+          expect(url).toBe(competitionOverviewPath);
+          expect(config).toMatchObject({
             headers: {
-              "content-type": "application/json",
+              accept: "application/json",
             },
-            status: 200,
-          },
-        );
-      },
+          });
+
+          return {
+            data: [
+              {
+                endsAt: "2026-05-05T21:00:00.000Z",
+                format: "round-robin",
+                id: "fa222204-b855-4fb0-b507-e169249e588e",
+                owner: {
+                  email: "lucia@example.com",
+                  id: "44e7eb17-a42b-4de8-bf34-2f8d78680d39",
+                  name: "Lucia Perez",
+                },
+                startsAt: "2026-05-03T12:00:00.000Z",
+                status: "open",
+                title: "North Circuit Masters",
+              },
+            ],
+          };
+        },
+        post: async () => ({ data: null }),
+      } as unknown as AxiosInstance,
     });
 
-    await expect(client.getCompetitionOverview()).resolves.toMatchObject([
+    await expect(apiClient.getCompetitionOverview()).resolves.toMatchObject([
       {
         status: "open",
         title: "North Circuit Masters",
@@ -188,19 +207,35 @@ describe("api-client package", () => {
   });
 
   it("throws a typed transport error for non-success responses", async () => {
-    const client = createApiClient({
-      fetch: async () =>
-        new Response(JSON.stringify({ message: "Backend unavailable" }), {
-          headers: {
-            "content-type": "application/json",
-          },
-          status: 503,
-        }),
+    const apiClient = createApiClient({
+      axios: {
+        defaults: {},
+        get: async () => {
+          throw new AxiosError(
+            "Request failed with status code 503",
+            "ERR_BAD_RESPONSE",
+            undefined,
+            undefined,
+            {
+              config: {
+                headers: new AxiosHeaders(),
+              } as InternalAxiosRequestConfig,
+              data: {
+                message: "Backend unavailable",
+              },
+              headers: {},
+              status: 503,
+              statusText: "Service Unavailable",
+            },
+          );
+        },
+        post: async () => ({ data: null }),
+      } as unknown as AxiosInstance,
     });
 
-    await expect(client.getCompetitionOverview()).rejects.toEqual(
+    await expect(apiClient.getCompetitionOverview()).rejects.toEqual(
       expect.objectContaining<ApiClientError>({
-        message: "Request failed with status 503.",
+        message: "Request failed with status code 503",
         responseBody: '{"message":"Backend unavailable"}',
         status: 503,
       }),

--- a/packages/api-client/test/index.test.ts
+++ b/packages/api-client/test/index.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import {
   ApiClientError,
   competitionOverviewPath,

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -86,7 +86,7 @@ export const signInEmailResponseSchema = authMutationResponseSchema;
 
 export const signOutResponseSchema = z
   .object({
-    success: z.boolean(),
+    success: z.literal(true),
   })
   .strict();
 

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -10,13 +10,16 @@ export const competitionFormatSchema = z.enum([
   "round-robin",
   "league",
 ]);
+
 export const authUserSchema = z
   .object({
     id: z.string(),
     email: z.email(),
     name: z.string(),
     emailVerified: z.boolean(),
-    image: z.url().nullable(),
+    image: z.string().url().nullable().optional(),
+    createdAt: z.iso.datetime().optional(),
+    updatedAt: z.iso.datetime().optional(),
   })
   .strict();
 
@@ -25,6 +28,11 @@ export const authSessionSchema = z
     id: z.string(),
     userId: z.string(),
     expiresAt: z.iso.datetime(),
+    createdAt: z.iso.datetime().optional(),
+    updatedAt: z.iso.datetime().optional(),
+    token: z.string().optional(),
+    ipAddress: z.string().nullable().optional(),
+    userAgent: z.string().nullable().optional(),
   })
   .strict();
 
@@ -45,6 +53,9 @@ export const signInWithEmailRequestSchema = z
 
 export const authMutationResponseSchema = z
   .object({
+    redirect: z.boolean().optional(),
+    token: z.string().nullable().optional(),
+    url: z.string().optional(),
     user: authUserSchema,
   })
   .strict();
@@ -68,11 +79,26 @@ export const authSessionResponseSchema = z.union([
   anonymousSessionResponseSchema,
 ]);
 
+export const signUpEmailRequestSchema = signUpWithEmailRequestSchema;
+export const signUpEmailResponseSchema = authMutationResponseSchema;
+export const signInEmailRequestSchema = signInWithEmailRequestSchema;
+export const signInEmailResponseSchema = authMutationResponseSchema;
+
 export const signOutResponseSchema = z
   .object({
-    success: z.literal(true),
+    success: z.boolean(),
   })
   .strict();
+
+export const currentSessionResponseSchema = authSessionResponseSchema.transform(
+  (value) =>
+    value.authenticated
+      ? {
+          session: value.session,
+          user: value.user,
+        }
+      : null,
+);
 
 export const authErrorSchema = z
   .object({
@@ -84,6 +110,7 @@ export const authErrorSchema = z
     message: z.string(),
   })
   .strict();
+
 export const createCompetitionRequestSchema = z
   .object({
     title: z.string().trim().min(1),
@@ -159,11 +186,18 @@ export type AuthUser = z.infer<typeof authUserSchema>;
 export type AnonymousSessionResponse = z.infer<
   typeof anonymousSessionResponseSchema
 >;
+export type CurrentSessionResponse = z.infer<
+  typeof currentSessionResponseSchema
+>;
 export type SharedPingContract = z.infer<typeof sharedPingContract>;
+export type SignInEmailRequest = z.infer<typeof signInEmailRequestSchema>;
+export type SignInEmailResponse = z.infer<typeof signInEmailResponseSchema>;
 export type SignInWithEmailRequest = z.infer<
   typeof signInWithEmailRequestSchema
 >;
 export type SignOutResponse = z.infer<typeof signOutResponseSchema>;
+export type SignUpEmailRequest = z.infer<typeof signUpEmailRequestSchema>;
+export type SignUpEmailResponse = z.infer<typeof signUpEmailResponseSchema>;
 export type SignUpWithEmailRequest = z.infer<
   typeof signUpWithEmailRequestSchema
 >;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       '@padel/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@tanstack/react-form':
+        specifier: 1.29.1
+        version: 1.29.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-query':
         specifier: ^5.100.7
         version: 5.100.7(react@19.2.5)
@@ -175,18 +178,30 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/user-event':
+        specifier: 14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/react':
         specifier: ^19.2.2
         version: 19.2.14
       '@types/react-dom':
         specifier: ^19.2.2
         version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: 26.1.0
+        version: 26.1.0
 
   packages/api-client:
     dependencies:
       '@padel/schemas':
         specifier: workspace:*
         version: link:../schemas
+      axios:
+        specifier: ^1.13.2
+        version: 1.15.2
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
   packages/config: {}
 
@@ -2141,12 +2156,33 @@ packages:
   '@tailwindcss/postcss@4.2.4':
     resolution: {integrity: sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==}
 
+  '@tanstack/devtools-event-client@0.4.3':
+    resolution: {integrity: sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@tanstack/form-core@1.29.1':
+    resolution: {integrity: sha512-NIYPO36eEu7nSWvMpbFDQaBWyVtnH/C8fsZ3/XpJUT4uOWgmxsiUvHGbTbDNIQTXAKIkhwEl0sUrqBNn2SfUnw==}
+
   '@tanstack/history@1.161.6':
     resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
     engines: {node: '>=20.19'}
 
+  '@tanstack/pacer-lite@0.1.1':
+    resolution: {integrity: sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w==}
+    engines: {node: '>=18'}
+
   '@tanstack/query-core@5.100.7':
     resolution: {integrity: sha512-5R7i6ENJLhVeeJrrUz7jKBXUXv/BJrxf9FQJSkR13bPrb3zOcE8A0Z0PxYCcsKPOsiIlTibrBL/zZbtUO1TFyQ==}
+
+  '@tanstack/react-form@1.29.1':
+    resolution: {integrity: sha512-hVHk4g0phd0HxRsv2ry6Xt8BqmalT55Q3cokhJBCC1St0hcGZhgwJJbohm9atao45BPG9e55DGvtbwExqZe35g==}
+    peerDependencies:
+      '@tanstack/react-start': '*'
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@tanstack/react-start':
+        optional: true
 
   '@tanstack/react-query@5.100.7':
     resolution: {integrity: sha512-LoISYWz8dOOuQbeIctF8K6yi42TWtR1WPGpwGuRUpF3u79JVVIg/PVR0MQdIA0VSHqD/ydf/b7PhKTkg3I4fLQ==}
@@ -6882,9 +6918,27 @@ snapshots:
       postcss: 8.5.12
       tailwindcss: 4.2.4
 
+  '@tanstack/devtools-event-client@0.4.3': {}
+
+  '@tanstack/form-core@1.29.1':
+    dependencies:
+      '@tanstack/devtools-event-client': 0.4.3
+      '@tanstack/pacer-lite': 0.1.1
+      '@tanstack/store': 0.9.3
+
   '@tanstack/history@1.161.6': {}
 
+  '@tanstack/pacer-lite@0.1.1': {}
+
   '@tanstack/query-core@5.100.7': {}
+
+  '@tanstack/react-form@1.29.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/form-core': 1.29.1
+      '@tanstack/react-store': 0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+    transitivePeerDependencies:
+      - react-dom
 
   '@tanstack/react-query@5.100.7(react@19.2.5)':
     dependencies:


### PR DESCRIPTION
## Summary
- add shared auth request and response schemas plus typed `packages/api-client` wrappers for sign-up, sign-in, sign-out, and current-session flows
- replace the placeholder `apps/web` shell with TanStack Router, TanStack Query, and TanStack Form based login and registration routes, guest-only redirects, and a post-login dashboard landing screen
- sync the docs-first execution artifacts so `TKT-042` is represented in backlog and sprint planning alongside the in-progress GitHub issue

## Testing
- `NX_DAEMON=false pnpm exec nx run @padel/api-client:test`
- `NX_DAEMON=false pnpm exec nx run @padel/web:test`
- `NX_DAEMON=false pnpm exec nx run @padel/web:typecheck`
- `NX_DAEMON=false pnpm exec nx run-many -t build --projects=@padel/schemas,@padel/api-client,@padel/ui,@padel/web`
- `NX_DAEMON=false pnpm exec nx run-many -t lint --projects=@padel/schemas,@padel/api-client,@padel/web`
- `git push` pre-push hook: affected lint/typecheck/test/build plus boundary validation
