### PR TITLE
feat(auth): add self-service auth contracts

### DIFF
--- a/apps/api/src/common/modules/auth/application/auth-gateway.error.ts
+++ b/apps/api/src/common/modules/auth/application/auth-gateway.error.ts
@@ -1,0 +1,15 @@
+export type AuthGatewayErrorCode =
+  | "auth_unavailable"
+  | "duplicate_email"
+  | "invalid_credentials";
+
+export class AuthGatewayError extends Error {
+  constructor(
+    readonly code: AuthGatewayErrorCode,
+    readonly statusCode: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AuthGatewayError";
+  }
+}

--- a/apps/api/src/common/modules/auth/application/get-auth-session.use-case.ts
+++ b/apps/api/src/common/modules/auth/application/get-auth-session.use-case.ts
@@ -1,0 +1,20 @@
+import type { IncomingHttpHeaders } from "node:http";
+
+import { Inject, Injectable } from "@nestjs/common";
+
+import {
+  type AuthGateway,
+  AuthGatewayToken,
+} from "./ports/auth-gateway.port.js";
+
+@Injectable()
+export class GetAuthSessionUseCase {
+  constructor(
+    @Inject(AuthGatewayToken)
+    private readonly authGateway: AuthGateway,
+  ) {}
+
+  async execute(headers: IncomingHttpHeaders) {
+    return this.authGateway.getSessionWithHeaders(headers);
+  }
+}

--- a/apps/api/src/common/modules/auth/application/ports/auth-gateway.port.ts
+++ b/apps/api/src/common/modules/auth/application/ports/auth-gateway.port.ts
@@ -1,24 +1,61 @@
-import type {
-  IncomingHttpHeaders,
-  IncomingMessage,
-  ServerResponse,
-} from "node:http";
+import type { IncomingHttpHeaders } from "node:http";
 
 export interface AuthSession {
-  session: Record<string, unknown>;
+  session: AuthSessionDetails;
   user: AuthenticatedUser;
 }
 
-export interface AuthenticatedUser extends Record<string, unknown> {
+export interface AuthSessionDetails {
   id: string;
+  userId: string;
+  expiresAt: string;
+}
+
+export interface AuthenticatedUser {
+  id: string;
+  email: string;
+  name: string;
+  emailVerified: boolean;
+  image: string | null;
+}
+
+export interface AuthResponseHeaders {
+  location?: string;
+  setCookie: string[];
+}
+
+export interface AuthResponse<T> {
+  data: T;
+  headers: AuthResponseHeaders;
+}
+
+export interface SignInWithEmailInput {
+  email: string;
+  password: string;
+}
+
+export interface SignUpWithEmailInput {
+  email: string;
+  name: string;
+  password: string;
 }
 
 export interface AuthGateway {
   getSession(headers: IncomingHttpHeaders): Promise<AuthSession | null>;
-  handleRequest(
-    request: IncomingMessage,
-    response: ServerResponse,
-  ): Promise<unknown>;
+  getSessionWithHeaders(
+    headers: IncomingHttpHeaders,
+  ): Promise<AuthResponse<AuthSession | null>>;
+  signInWithEmail(
+    headers: IncomingHttpHeaders,
+    input: SignInWithEmailInput,
+  ): Promise<AuthResponse<{ user: AuthenticatedUser }>>;
+  signOut(
+    headers: IncomingHttpHeaders,
+  ): Promise<AuthResponse<{ success: true }>>;
+  signUpWithEmail(
+    headers: IncomingHttpHeaders,
+    input: SignUpWithEmailInput,
+  ): Promise<AuthResponse<{ user: AuthenticatedUser }>>;
 }
 
 export const AuthGatewayToken = Symbol("AuthGateway");

--- a/apps/api/src/common/modules/auth/application/resolve-auth-session.use-case.test.ts
+++ b/apps/api/src/common/modules/auth/application/resolve-auth-session.use-case.test.ts
@@ -8,15 +8,28 @@ import { ResolveAuthSessionUseCase } from "./resolve-auth-session.use-case.js";
 describe("ResolveAuthSessionUseCase", () => {
   it("delegates session lookup to the auth gateway", async () => {
     const session = {
-      session: { id: "session-1" },
-      user: { id: "user-1" },
+      session: {
+        id: "session-1",
+        userId: "user-1",
+        expiresAt: "2026-05-10T10:00:00.000Z",
+      },
+      user: {
+        id: "user-1",
+        email: "user@example.com",
+        name: "Auth User",
+        emailVerified: false,
+        image: null,
+      },
     };
     const getSession = vi
       .fn<AuthGateway["getSession"]>()
       .mockResolvedValue(session);
     const authGateway: AuthGateway = {
       getSession,
-      handleRequest: vi.fn(),
+      getSessionWithHeaders: vi.fn(),
+      signInWithEmail: vi.fn(),
+      signOut: vi.fn(),
+      signUpWithEmail: vi.fn(),
     };
     const headers: IncomingHttpHeaders = {
       cookie: "better-auth.session_token=test",

--- a/apps/api/src/common/modules/auth/application/sign-in-with-email.use-case.ts
+++ b/apps/api/src/common/modules/auth/application/sign-in-with-email.use-case.ts
@@ -1,0 +1,22 @@
+import type { IncomingHttpHeaders } from "node:http";
+
+import { Inject, Injectable } from "@nestjs/common";
+
+import type { SignInWithEmailRequest } from "@padel/schemas";
+
+import {
+  type AuthGateway,
+  AuthGatewayToken,
+} from "./ports/auth-gateway.port.js";
+
+@Injectable()
+export class SignInWithEmailUseCase {
+  constructor(
+    @Inject(AuthGatewayToken)
+    private readonly authGateway: AuthGateway,
+  ) {}
+
+  async execute(headers: IncomingHttpHeaders, request: SignInWithEmailRequest) {
+    return this.authGateway.signInWithEmail(headers, request);
+  }
+}

--- a/apps/api/src/common/modules/auth/application/sign-out.use-case.ts
+++ b/apps/api/src/common/modules/auth/application/sign-out.use-case.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage, ServerResponse } from "node:http";
+import type { IncomingHttpHeaders } from "node:http";
 
 import { Inject, Injectable } from "@nestjs/common";
 
@@ -8,13 +8,13 @@ import {
 } from "./ports/auth-gateway.port.js";
 
 @Injectable()
-export class HandleAuthRequestUseCase {
+export class SignOutUseCase {
   constructor(
     @Inject(AuthGatewayToken)
     private readonly authGateway: AuthGateway,
   ) {}
 
-  async execute(request: IncomingMessage, response: ServerResponse) {
-    return this.authGateway.handleRequest(request, response);
+  async execute(headers: IncomingHttpHeaders) {
+    return this.authGateway.signOut(headers);
   }
 }

--- a/apps/api/src/common/modules/auth/application/sign-up-with-email.use-case.ts
+++ b/apps/api/src/common/modules/auth/application/sign-up-with-email.use-case.ts
@@ -1,0 +1,22 @@
+import type { IncomingHttpHeaders } from "node:http";
+
+import { Inject, Injectable } from "@nestjs/common";
+
+import type { SignUpWithEmailRequest } from "@padel/schemas";
+
+import {
+  type AuthGateway,
+  AuthGatewayToken,
+} from "./ports/auth-gateway.port.js";
+
+@Injectable()
+export class SignUpWithEmailUseCase {
+  constructor(
+    @Inject(AuthGatewayToken)
+    private readonly authGateway: AuthGateway,
+  ) {}
+
+  async execute(headers: IncomingHttpHeaders, request: SignUpWithEmailRequest) {
+    return this.authGateway.signUpWithEmail(headers, request);
+  }
+}

--- a/apps/api/src/common/modules/auth/auth.module.ts
+++ b/apps/api/src/common/modules/auth/auth.module.ts
@@ -1,18 +1,26 @@
 import { Global, Module } from "@nestjs/common";
 import { PrismaModule } from "../../../prisma/prisma.module.js";
-import { HandleAuthRequestUseCase } from "./application/handle-auth-request.use-case.js";
+import { GetAuthSessionUseCase } from "./application/get-auth-session.use-case.js";
 import { AuthGatewayToken } from "./application/ports/auth-gateway.port.js";
 import { ResolveAuthSessionUseCase } from "./application/resolve-auth-session.use-case.js";
+import { SignInWithEmailUseCase } from "./application/sign-in-with-email.use-case.js";
+import { SignOutUseCase } from "./application/sign-out.use-case.js";
+import { SignUpWithEmailUseCase } from "./application/sign-up-with-email.use-case.js";
+import { AuthController } from "./inbound/http/auth.controller.js";
 import { AuthenticatedGuard } from "./inbound/http/authenticated.guard.js";
 import { BetterAuthGateway } from "./outbound/better-auth.gateway.js";
 
 @Global()
 @Module({
   imports: [PrismaModule],
+  controllers: [AuthController],
   providers: [
     BetterAuthGateway,
-    HandleAuthRequestUseCase,
+    GetAuthSessionUseCase,
     ResolveAuthSessionUseCase,
+    SignInWithEmailUseCase,
+    SignOutUseCase,
+    SignUpWithEmailUseCase,
     AuthenticatedGuard,
     {
       provide: AuthGatewayToken,
@@ -21,8 +29,11 @@ import { BetterAuthGateway } from "./outbound/better-auth.gateway.js";
   ],
   exports: [
     AuthGatewayToken,
-    HandleAuthRequestUseCase,
+    GetAuthSessionUseCase,
     ResolveAuthSessionUseCase,
+    SignInWithEmailUseCase,
+    SignOutUseCase,
+    SignUpWithEmailUseCase,
     AuthenticatedGuard,
   ],
 })

--- a/apps/api/src/common/modules/auth/inbound/http/apply-auth-response-headers.ts
+++ b/apps/api/src/common/modules/auth/inbound/http/apply-auth-response-headers.ts
@@ -1,0 +1,16 @@
+import type { Response } from "express";
+
+import type { AuthResponseHeaders } from "../../application/ports/auth-gateway.port.js";
+
+export function applyAuthResponseHeaders(
+  response: Response,
+  headers: AuthResponseHeaders,
+) {
+  if (headers.location) {
+    response.setHeader("location", headers.location);
+  }
+
+  if (headers.setCookie.length > 0) {
+    response.setHeader("set-cookie", headers.setCookie);
+  }
+}

--- a/apps/api/src/common/modules/auth/inbound/http/auth.controller.integration.test.ts
+++ b/apps/api/src/common/modules/auth/inbound/http/auth.controller.integration.test.ts
@@ -74,25 +74,26 @@ describe.skipIf(!canRunDatabaseTests)("AuthController integration", () => {
     await prisma?.$disconnect();
   });
 
-  it("creates a persisted auth session and reads it back through Better Auth", async () => {
+  it("creates a persisted auth session and reads it back through the app-owned auth contract", async () => {
     const agent = request.agent(app.getHttpServer());
     const email = `auth-${randomUUID()}@example.com`;
 
     const signUpResponse = await agent
-      .post("/auth/sign-up/email")
+      .post("/auth/sign-up")
       .set("origin", "http://localhost:3000")
       .send({
         name: "Auth Test User",
         email,
         password: "password-1234",
       })
-      .expect(200);
+      .expect(201);
 
     expect(signUpResponse.body).toMatchObject({
       user: {
         email,
         name: "Auth Test User",
         emailVerified: false,
+        image: null,
       },
     });
     expect(signUpResponse.headers["set-cookie"]).toBeDefined();
@@ -112,17 +113,107 @@ describe.skipIf(!canRunDatabaseTests)("AuthController integration", () => {
     });
     expect(user.sessions).toHaveLength(1);
 
-    const sessionResponse = await agent.get("/auth/get-session").expect(200);
+    const sessionResponse = await agent.get("/auth/session").expect(200);
 
     expect(sessionResponse.body).toMatchObject({
+      authenticated: true,
       user: {
         id: user.id,
         email,
         name: "Auth Test User",
+        image: null,
       },
       session: {
+        id: user.sessions[0].id,
         userId: user.id,
+        expiresAt: user.sessions[0].expiresAt.toISOString(),
       },
+    });
+  });
+
+  it("returns an explicit invalid-credentials error for a failed sign-in", async () => {
+    const agent = request.agent(app.getHttpServer());
+    const email = `auth-${randomUUID()}@example.com`;
+
+    await agent
+      .post("/auth/sign-up")
+      .set("origin", "http://localhost:3000")
+      .send({
+        name: "Auth Test User",
+        email,
+        password: "password-1234",
+      })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .post("/auth/sign-in")
+      .set("origin", "http://localhost:3000")
+      .send({
+        email,
+        password: "wrong-password",
+      })
+      .expect(401)
+      .expect(({ body }: { body: unknown }) => {
+        expect(body).toEqual({
+          code: "invalid_credentials",
+          message: "Email or password is incorrect.",
+        });
+      });
+  });
+
+  it("returns an explicit duplicate-account error for repeated sign-up", async () => {
+    const email = `auth-${randomUUID()}@example.com`;
+
+    await request(app.getHttpServer())
+      .post("/auth/sign-up")
+      .set("origin", "http://localhost:3000")
+      .send({
+        name: "Auth Test User",
+        email,
+        password: "password-1234",
+      })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .post("/auth/sign-up")
+      .set("origin", "http://localhost:3000")
+      .send({
+        name: "Auth Test User",
+        email,
+        password: "password-1234",
+      })
+      .expect(409)
+      .expect(({ body }: { body: unknown }) => {
+        expect(body).toEqual({
+          code: "duplicate_email",
+          message: "An account with that email already exists.",
+        });
+      });
+  });
+
+  it("clears the session and reports an anonymous state after sign-out", async () => {
+    const agent = request.agent(app.getHttpServer());
+    const email = `auth-${randomUUID()}@example.com`;
+
+    await agent
+      .post("/auth/sign-up")
+      .set("origin", "http://localhost:3000")
+      .send({
+        name: "Auth Test User",
+        email,
+        password: "password-1234",
+      })
+      .expect(201);
+
+    const signOutResponse = await agent.post("/auth/sign-out").expect(200);
+
+    expect(signOutResponse.body).toEqual({
+      success: true,
+    });
+    expect(signOutResponse.headers["set-cookie"]).toBeDefined();
+
+    await agent.get("/auth/session").expect(200).expect({
+      authenticated: false,
     });
   });
 });

--- a/apps/api/src/common/modules/auth/inbound/http/auth.controller.test.ts
+++ b/apps/api/src/common/modules/auth/inbound/http/auth.controller.test.ts
@@ -1,0 +1,206 @@
+import "reflect-metadata";
+
+import { ExpressAdapter } from "@nestjs/platform-express";
+import { Test } from "@nestjs/testing";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+
+import { AuthGatewayError } from "../../application/auth-gateway.error.js";
+import { GetAuthSessionUseCase } from "../../application/get-auth-session.use-case.js";
+import { SignInWithEmailUseCase } from "../../application/sign-in-with-email.use-case.js";
+import { SignOutUseCase } from "../../application/sign-out.use-case.js";
+import { SignUpWithEmailUseCase } from "../../application/sign-up-with-email.use-case.js";
+import { AuthController } from "./auth.controller.js";
+
+describe("AuthController", () => {
+  it("creates an app-owned sign-up response", async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [
+        {
+          provide: GetAuthSessionUseCase,
+          useValue: {
+            execute: async () => ({ data: null, headers: { setCookie: [] } }),
+          },
+        },
+        {
+          provide: SignUpWithEmailUseCase,
+          useValue: {
+            execute: async () => ({
+              data: {
+                user: {
+                  id: "user-1",
+                  email: "ops@example.com",
+                  name: "Operations User",
+                  emailVerified: false,
+                  image: null,
+                },
+              },
+              headers: {
+                setCookie: ["session=test; Path=/; HttpOnly"],
+              },
+            }),
+          },
+        },
+        {
+          provide: SignInWithEmailUseCase,
+          useValue: {
+            execute: async () => ({ data: null, headers: { setCookie: [] } }),
+          },
+        },
+        {
+          provide: SignOutUseCase,
+          useValue: {
+            execute: async () => ({
+              data: { success: true },
+              headers: { setCookie: [] },
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    const app = moduleRef.createNestApplication(new ExpressAdapter());
+    await app.init();
+
+    await request(app.getHttpServer())
+      .post("/auth/sign-up")
+      .send({
+        name: "Operations User",
+        email: "ops@example.com",
+        password: "password-1234",
+      })
+      .expect(201)
+      .expect(
+        ({
+          body,
+          headers,
+        }: { body: unknown; headers: Record<string, unknown> }) => {
+          expect(body).toEqual({
+            user: {
+              id: "user-1",
+              email: "ops@example.com",
+              name: "Operations User",
+              emailVerified: false,
+              image: null,
+            },
+          });
+          expect(headers["set-cookie"]).toBeDefined();
+        },
+      );
+
+    await app.close();
+  });
+
+  it("maps invalid credentials into an explicit auth error payload", async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [
+        {
+          provide: GetAuthSessionUseCase,
+          useValue: {
+            execute: async () => ({ data: null, headers: { setCookie: [] } }),
+          },
+        },
+        {
+          provide: SignUpWithEmailUseCase,
+          useValue: {
+            execute: async () => ({ data: null, headers: { setCookie: [] } }),
+          },
+        },
+        {
+          provide: SignInWithEmailUseCase,
+          useValue: {
+            execute: async () => {
+              throw new AuthGatewayError(
+                "invalid_credentials",
+                401,
+                "Email or password is incorrect.",
+              );
+            },
+          },
+        },
+        {
+          provide: SignOutUseCase,
+          useValue: {
+            execute: async () => ({
+              data: { success: true },
+              headers: { setCookie: [] },
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    const app = moduleRef.createNestApplication(new ExpressAdapter());
+    await app.init();
+
+    await request(app.getHttpServer())
+      .post("/auth/sign-in")
+      .send({
+        email: "ops@example.com",
+        password: "password-1234",
+      })
+      .expect(401)
+      .expect(({ body }: { body: unknown }) => {
+        expect(body).toEqual({
+          code: "invalid_credentials",
+          message: "Email or password is incorrect.",
+        });
+      });
+
+    await app.close();
+  });
+
+  it("returns an explicit anonymous session state", async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [
+        {
+          provide: GetAuthSessionUseCase,
+          useValue: {
+            execute: async () => ({
+              data: null,
+              headers: { setCookie: [] },
+            }),
+          },
+        },
+        {
+          provide: SignUpWithEmailUseCase,
+          useValue: {
+            execute: async () => ({ data: null, headers: { setCookie: [] } }),
+          },
+        },
+        {
+          provide: SignInWithEmailUseCase,
+          useValue: {
+            execute: async () => ({ data: null, headers: { setCookie: [] } }),
+          },
+        },
+        {
+          provide: SignOutUseCase,
+          useValue: {
+            execute: async () => ({
+              data: { success: true },
+              headers: { setCookie: [] },
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    const app = moduleRef.createNestApplication(new ExpressAdapter());
+    await app.init();
+
+    await request(app.getHttpServer())
+      .get("/auth/session")
+      .expect(200)
+      .expect(({ body }: { body: unknown }) => {
+        expect(body).toEqual({
+          authenticated: false,
+        });
+      });
+
+    await app.close();
+  });
+});

--- a/apps/api/src/common/modules/auth/inbound/http/auth.controller.ts
+++ b/apps/api/src/common/modules/auth/inbound/http/auth.controller.ts
@@ -1,0 +1,134 @@
+import type { Request, Response } from "express";
+
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  Post,
+  Req,
+  Res,
+} from "@nestjs/common";
+import {
+  authErrorSchema,
+  authMutationResponseSchema,
+  authSessionResponseSchema,
+  signInWithEmailRequestSchema,
+  signOutResponseSchema,
+  signUpWithEmailRequestSchema,
+} from "@padel/schemas";
+
+import { AuthGatewayError } from "../../application/auth-gateway.error.js";
+import { GetAuthSessionUseCase } from "../../application/get-auth-session.use-case.js";
+import { SignInWithEmailUseCase } from "../../application/sign-in-with-email.use-case.js";
+import { SignOutUseCase } from "../../application/sign-out.use-case.js";
+import { SignUpWithEmailUseCase } from "../../application/sign-up-with-email.use-case.js";
+import { applyAuthResponseHeaders } from "./apply-auth-response-headers.js";
+
+@Controller("auth")
+export class AuthController {
+  constructor(
+    @Inject(GetAuthSessionUseCase)
+    private readonly getAuthSessionUseCase: GetAuthSessionUseCase,
+    @Inject(SignUpWithEmailUseCase)
+    private readonly signUpWithEmailUseCase: SignUpWithEmailUseCase,
+    @Inject(SignInWithEmailUseCase)
+    private readonly signInWithEmailUseCase: SignInWithEmailUseCase,
+    @Inject(SignOutUseCase)
+    private readonly signOutUseCase: SignOutUseCase,
+  ) {}
+
+  @Post("sign-up")
+  @HttpCode(HttpStatus.CREATED)
+  async signUp(
+    @Req() request: Request,
+    @Res({ passthrough: true }) response: Response,
+    @Body() body: unknown,
+  ) {
+    const authRequest = signUpWithEmailRequestSchema.parse(body);
+
+    try {
+      const result = await this.signUpWithEmailUseCase.execute(
+        request.headers,
+        authRequest,
+      );
+
+      applyAuthResponseHeaders(response, result.headers);
+
+      return authMutationResponseSchema.parse(result.data);
+    } catch (error) {
+      return this.handleAuthError(response, error);
+    }
+  }
+
+  @Post("sign-in")
+  async signIn(
+    @Req() request: Request,
+    @Res({ passthrough: true }) response: Response,
+    @Body() body: unknown,
+  ) {
+    const authRequest = signInWithEmailRequestSchema.parse(body);
+
+    try {
+      const result = await this.signInWithEmailUseCase.execute(
+        request.headers,
+        authRequest,
+      );
+
+      applyAuthResponseHeaders(response, result.headers);
+
+      return authMutationResponseSchema.parse(result.data);
+    } catch (error) {
+      return this.handleAuthError(response, error);
+    }
+  }
+
+  @Post("sign-out")
+  @HttpCode(HttpStatus.OK)
+  async signOut(
+    @Req() request: Request,
+    @Res({ passthrough: true }) response: Response,
+  ) {
+    const result = await this.signOutUseCase.execute(request.headers);
+
+    applyAuthResponseHeaders(response, result.headers);
+
+    return signOutResponseSchema.parse(result.data);
+  }
+
+  @Get("session")
+  async getCurrentSession(
+    @Req() request: Request,
+    @Res({ passthrough: true }) response: Response,
+  ) {
+    const result = await this.getAuthSessionUseCase.execute(request.headers);
+
+    applyAuthResponseHeaders(response, result.headers);
+
+    if (!result.data) {
+      return authSessionResponseSchema.parse({
+        authenticated: false,
+      });
+    }
+
+    return authSessionResponseSchema.parse({
+      authenticated: true,
+      session: result.data.session,
+      user: result.data.user,
+    });
+  }
+
+  private handleAuthError(response: Response, error: unknown) {
+    if (error instanceof AuthGatewayError) {
+      response.status(error.statusCode);
+      return authErrorSchema.parse({
+        code: error.code,
+        message: error.message,
+      });
+    }
+
+    throw error;
+  }
+}

--- a/apps/api/src/common/modules/auth/inbound/http/current-user.decorator.ts
+++ b/apps/api/src/common/modules/auth/inbound/http/current-user.decorator.ts
@@ -7,6 +7,6 @@ export const CurrentUser = createParamDecorator(
     const request = context.switchToHttp().getRequest<RequestWithAuthContext>();
     const user = request.user;
 
-    return data ? user?.[data] : user;
+    return data ? user?.[data as keyof typeof user] : user;
   },
 );

--- a/apps/api/src/common/modules/auth/outbound/better-auth.gateway.ts
+++ b/apps/api/src/common/modules/auth/outbound/better-auth.gateway.ts
@@ -1,19 +1,21 @@
-import type {
-  IncomingHttpHeaders,
-  IncomingMessage,
-  ServerResponse,
-} from "node:http";
+import type { IncomingHttpHeaders } from "node:http";
 
 import { Inject, Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
-import { fromNodeHeaders, toNodeHandler } from "better-auth/node";
+import { isAPIError } from "better-auth/api";
+import { fromNodeHeaders } from "better-auth/node";
 
 import { PrismaService } from "../../../../prisma/prisma.service.js";
+import { AuthGatewayError } from "../application/auth-gateway.error.js";
 import type {
   AuthGateway,
+  AuthResponse,
   AuthSession,
+  AuthenticatedUser,
+  SignInWithEmailInput,
+  SignUpWithEmailInput,
 } from "../application/ports/auth-gateway.port.js";
 
 @Injectable()
@@ -38,12 +40,164 @@ export class BetterAuthGateway implements AuthGateway {
   }
 
   async getSession(headers: IncomingHttpHeaders): Promise<AuthSession | null> {
-    return (await this.auth.api.getSession({
-      headers: fromNodeHeaders(headers),
-    })) as AuthSession | null;
+    return this.mapSession(
+      await this.auth.api.getSession({
+        headers: fromNodeHeaders(headers),
+      }),
+    );
   }
 
-  async handleRequest(request: IncomingMessage, response: ServerResponse) {
-    return toNodeHandler(this.auth)(request, response);
+  async getSessionWithHeaders(
+    headers: IncomingHttpHeaders,
+  ): Promise<AuthResponse<AuthSession | null>> {
+    const result = await this.auth.api.getSession({
+      headers: fromNodeHeaders(headers),
+      returnHeaders: true,
+    });
+
+    return {
+      data: this.mapSession(result.response),
+      headers: this.mapHeaders(result.headers),
+    };
+  }
+
+  async signInWithEmail(
+    headers: IncomingHttpHeaders,
+    input: SignInWithEmailInput,
+  ): Promise<AuthResponse<{ user: AuthenticatedUser }>> {
+    try {
+      const result = await this.auth.api.signInEmail({
+        headers: fromNodeHeaders(headers),
+        body: input,
+        returnHeaders: true,
+      });
+
+      return {
+        data: {
+          user: this.mapUser(result.response.user),
+        },
+        headers: this.mapHeaders(result.headers),
+      };
+    } catch (error) {
+      throw this.mapError(error);
+    }
+  }
+
+  async signOut(
+    headers: IncomingHttpHeaders,
+  ): Promise<AuthResponse<{ success: true }>> {
+    const result = await this.auth.api.signOut({
+      headers: fromNodeHeaders(headers),
+      returnHeaders: true,
+    });
+
+    return {
+      data: {
+        success: result.response.success as true,
+      },
+      headers: this.mapHeaders(result.headers),
+    };
+  }
+
+  async signUpWithEmail(
+    headers: IncomingHttpHeaders,
+    input: SignUpWithEmailInput,
+  ): Promise<AuthResponse<{ user: AuthenticatedUser }>> {
+    try {
+      const result = await this.auth.api.signUpEmail({
+        headers: fromNodeHeaders(headers),
+        body: input,
+        returnHeaders: true,
+      });
+
+      return {
+        data: {
+          user: this.mapUser(result.response.user),
+        },
+        headers: this.mapHeaders(result.headers),
+      };
+    } catch (error) {
+      throw this.mapError(error);
+    }
+  }
+
+  private mapError(error: unknown) {
+    if (isAPIError(error)) {
+      const code = error.body?.code;
+
+      if (code === "USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL") {
+        return new AuthGatewayError(
+          "duplicate_email",
+          409,
+          "An account with that email already exists.",
+        );
+      }
+
+      if (code === "INVALID_EMAIL_OR_PASSWORD") {
+        return new AuthGatewayError(
+          "invalid_credentials",
+          401,
+          "Email or password is incorrect.",
+        );
+      }
+    }
+
+    return error;
+  }
+
+  private mapHeaders(headers: Headers) {
+    return {
+      location: headers.get("location") ?? undefined,
+      setCookie:
+        typeof headers.getSetCookie === "function"
+          ? headers.getSetCookie()
+          : [],
+    };
+  }
+
+  private mapSession(session: unknown): AuthSession | null {
+    if (!session) {
+      return null;
+    }
+
+    const typedSession = session as {
+      session: {
+        id: string;
+        userId: string;
+        expiresAt: Date;
+      };
+      user: {
+        id: string;
+        email: string;
+        name: string;
+        emailVerified: boolean;
+        image?: string | null;
+      };
+    };
+
+    return {
+      session: {
+        id: typedSession.session.id,
+        userId: typedSession.session.userId,
+        expiresAt: typedSession.session.expiresAt.toISOString(),
+      },
+      user: this.mapUser(typedSession.user),
+    };
+  }
+
+  private mapUser(user: {
+    id: string;
+    email: string;
+    name: string;
+    emailVerified: boolean;
+    image?: string | null;
+  }): AuthenticatedUser {
+    return {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      emailVerified: user.emailVerified,
+      image: user.image ?? null,
+    };
   }
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -2,12 +2,10 @@ import "reflect-metadata";
 
 import { ValidationPipe } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
-import type { Request, Response } from "express";
 import { Logger } from "nestjs-pino";
 
 import { AppModule } from "./app.module.js";
 import { GlobalExceptionFilter } from "./common/filters/global-exception/global-exception.filter.js";
-import { HandleAuthRequestUseCase } from "./common/modules/auth/application/handle-auth-request.use-case.js";
 
 export async function createApp() {
   const app = await NestFactory.create(AppModule, {
@@ -23,12 +21,6 @@ export async function createApp() {
       forbidNonWhitelisted: true,
     }),
   );
-
-  const handleAuthRequestUseCase = app.get(HandleAuthRequestUseCase);
-
-  app.use("/auth", (req: Request, res: Response) => {
-    void handleAuthRequestUseCase.execute(req, res);
-  });
 
   return app;
 }

--- a/docs/15-developer-experience/auth-local-workflow.md
+++ b/docs/15-developer-experience/auth-local-workflow.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Document the local Better Auth setup, session policy, and the minimum validation flow for the authentication foundation.
+Document the local Better Auth setup, session policy, and the backend-owned self-service auth flow.
 
 ## Environment variables
 
@@ -21,14 +21,16 @@ BETTER_AUTH_URL=http://localhost:3000
 
 ## Local session and cookie baseline
 
-`TKT-016` establishes the first owned session path using Better Auth with PostgreSQL-backed persistence in `apps/api`.
+`TKT-016` established the Better Auth runtime foundation. `TKT-043` adds explicit backend-owned self-service auth contracts on top of that foundation in `apps/api`.
 
 Current local behavior:
 
 - email and password is the enabled baseline sign-in method
 - Better Auth owns the session, account, verification, and cookie mechanics at the platform edge
 - the backend consumes authenticated identity through explicit auth boundaries rather than importing Better Auth types into competition domain code
-- sign-up and sign-in create a persisted session row in PostgreSQL and set a session cookie on the HTTP response
+- `POST /auth/sign-up` and `POST /auth/sign-in` create a persisted session row in PostgreSQL and set a session cookie on the HTTP response
+- `POST /auth/sign-out` clears the current session cookie and deletes the session row when present
+- `GET /auth/session` returns `{ authenticated: false }` when no valid session is present
 
 Operational guidance:
 
@@ -74,8 +76,9 @@ pnpm --filter @padel/api test:integration:db
 That suite verifies:
 
 - Prisma-backed competition persistence against PostgreSQL
-- Better Auth sign-up creates user, account, and session rows in PostgreSQL
-- Better Auth can read the established session back through `/auth/get-session`
+- app-owned auth sign-up creates user, account, and session rows in PostgreSQL
+- invalid credentials and duplicate sign-up attempts return explicit auth error payloads
+- the established session can be read back through `GET /auth/session`
 
 ## Manual end-to-end session check
 
@@ -89,7 +92,7 @@ curl -i \
   -H 'Content-Type: application/json' \
   -c /tmp/padel-auth-cookie.txt \
   -d '{"name":"Local Auth User","email":"local-auth@example.com","password":"password-1234"}' \
-  http://localhost:3000/auth/sign-up/email
+  http://localhost:3000/auth/sign-up
 ```
 
 2. Read the current session using the stored cookie:
@@ -97,13 +100,31 @@ curl -i \
 ```bash
 curl -i \
   -b /tmp/padel-auth-cookie.txt \
-  http://localhost:3000/auth/get-session
+  http://localhost:3000/auth/session
+```
+
+3. Sign out and confirm the session is gone:
+
+```bash
+curl -i \
+  -b /tmp/padel-auth-cookie.txt \
+  -c /tmp/padel-auth-cookie.txt \
+  -X POST \
+  http://localhost:3000/auth/sign-out
+```
+
+```bash
+curl -i \
+  -b /tmp/padel-auth-cookie.txt \
+  http://localhost:3000/auth/session
 ```
 
 Expected result:
 
-- the first response returns a user payload and a `Set-Cookie` header
-- the second response returns a `session` object and the same user identity
+- the first response returns a backend-owned `{ user }` payload and a `Set-Cookie` header
+- the second response returns `{ authenticated: true, session, user }`
+- the sign-out response returns `{ success: true }` and a clearing `Set-Cookie` header
+- the final session check returns `{ authenticated: false }`
 - PostgreSQL contains corresponding `user`, `account`, and `session` rows
 
 ## Boundary reminder

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -10,7 +10,80 @@ export const competitionFormatSchema = z.enum([
   "round-robin",
   "league",
 ]);
+export const authUserSchema = z
+  .object({
+    id: z.string(),
+    email: z.email(),
+    name: z.string(),
+    emailVerified: z.boolean(),
+    image: z.url().nullable(),
+  })
+  .strict();
 
+export const authSessionSchema = z
+  .object({
+    id: z.string(),
+    userId: z.string(),
+    expiresAt: z.iso.datetime(),
+  })
+  .strict();
+
+export const signUpWithEmailRequestSchema = z
+  .object({
+    name: z.string().trim().min(1),
+    email: z.email(),
+    password: z.string().min(8).max(128),
+  })
+  .strict();
+
+export const signInWithEmailRequestSchema = z
+  .object({
+    email: z.email(),
+    password: z.string().min(8).max(128),
+  })
+  .strict();
+
+export const authMutationResponseSchema = z
+  .object({
+    user: authUserSchema,
+  })
+  .strict();
+
+export const authenticatedSessionResponseSchema = z
+  .object({
+    authenticated: z.literal(true),
+    user: authUserSchema,
+    session: authSessionSchema,
+  })
+  .strict();
+
+export const anonymousSessionResponseSchema = z
+  .object({
+    authenticated: z.literal(false),
+  })
+  .strict();
+
+export const authSessionResponseSchema = z.union([
+  authenticatedSessionResponseSchema,
+  anonymousSessionResponseSchema,
+]);
+
+export const signOutResponseSchema = z
+  .object({
+    success: z.literal(true),
+  })
+  .strict();
+
+export const authErrorSchema = z
+  .object({
+    code: z.enum([
+      "duplicate_email",
+      "invalid_credentials",
+      "auth_unavailable",
+    ]),
+    message: z.string(),
+  })
+  .strict();
 export const createCompetitionRequestSchema = z
   .object({
     title: z.string().trim().min(1),
@@ -78,4 +151,19 @@ export type CompetitionOverviewItem = z.infer<
 export type CompetitionOverviewCollection = z.infer<
   typeof competitionOverviewCollectionSchema
 >;
+export type AuthError = z.infer<typeof authErrorSchema>;
+export type AuthMutationResponse = z.infer<typeof authMutationResponseSchema>;
+export type AuthSession = z.infer<typeof authSessionSchema>;
+export type AuthSessionResponse = z.infer<typeof authSessionResponseSchema>;
+export type AuthUser = z.infer<typeof authUserSchema>;
+export type AnonymousSessionResponse = z.infer<
+  typeof anonymousSessionResponseSchema
+>;
 export type SharedPingContract = z.infer<typeof sharedPingContract>;
+export type SignInWithEmailRequest = z.infer<
+  typeof signInWithEmailRequestSchema
+>;
+export type SignOutResponse = z.infer<typeof signOutResponseSchema>;
+export type SignUpWithEmailRequest = z.infer<
+  typeof signUpWithEmailRequestSchema
+>;

--- a/packages/schemas/test/index.test.ts
+++ b/packages/schemas/test/index.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   authErrorSchema,
-  authSessionResponseSchema,
   authMutationResponseSchema,
+  authSessionResponseSchema,
   competitionOverviewCollectionSchema,
   createCompetitionRequestSchema,
   createCompetitionResponseSchema,

--- a/packages/schemas/test/index.test.ts
+++ b/packages/schemas/test/index.test.ts
@@ -1,10 +1,87 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  authErrorSchema,
+  authSessionResponseSchema,
+  authMutationResponseSchema,
   competitionOverviewCollectionSchema,
   createCompetitionRequestSchema,
   createCompetitionResponseSchema,
+  signInWithEmailRequestSchema,
+  signOutResponseSchema,
+  signUpWithEmailRequestSchema,
 } from "../src/index.js";
+
+describe("auth schemas", () => {
+  it("parses a valid sign-up request", () => {
+    expect(
+      signUpWithEmailRequestSchema.parse({
+        name: "Operations User",
+        email: "ops@example.com",
+        password: "password-1234",
+      }),
+    ).toMatchObject({
+      email: "ops@example.com",
+      name: "Operations User",
+    });
+  });
+
+  it("rejects a sign-in request with a short password", () => {
+    expect(() =>
+      signInWithEmailRequestSchema.parse({
+        email: "ops@example.com",
+        password: "short",
+      }),
+    ).toThrow();
+  });
+
+  it("parses an authenticated auth response", () => {
+    expect(
+      authMutationResponseSchema.parse({
+        user: {
+          id: "user-1",
+          email: "ops@example.com",
+          name: "Operations User",
+          emailVerified: false,
+          image: null,
+        },
+      }),
+    ).toMatchObject({
+      user: {
+        id: "user-1",
+      },
+    });
+  });
+
+  it("parses an anonymous session response", () => {
+    expect(
+      authSessionResponseSchema.parse({
+        authenticated: false,
+      }),
+    ).toEqual({
+      authenticated: false,
+    });
+  });
+
+  it("parses an auth error payload", () => {
+    expect(
+      authErrorSchema.parse({
+        code: "invalid_credentials",
+        message: "Email or password is incorrect.",
+      }),
+    ).toMatchObject({
+      code: "invalid_credentials",
+    });
+  });
+
+  it("rejects a sign-out response that is not successful", () => {
+    expect(() =>
+      signOutResponseSchema.parse({
+        success: false,
+      }),
+    ).toThrow();
+  });
+});
 
 describe("competition schemas", () => {
   it("parses a valid create-competition request", () => {


### PR DESCRIPTION
## Summary
- replace the raw Better Auth pass-through with backend-owned auth endpoints in `apps/api`
- publish shared sign-up, sign-in, sign-out, session, and auth error contracts from `packages/schemas`
- document the local self-service auth workflow and cookie/session behavior for frontend consumers

## Testing
- `pnpm --filter @padel/schemas lint`
- `pnpm --filter @padel/schemas test`
- `pnpm --filter @padel/api lint`
- `pnpm --filter @padel/api typecheck`
- `pnpm --filter @padel/api test`
- `DATABASE_URL='postgresql://padel:padel@localhost:5433/padel?schema=public' pnpm --filter @padel/api test:integration:db`
- `git push -u origin codex/issue-43-auth-self-service` (pre-push hook ran Nx affected lint/typecheck/test/build and boundary checks)

Closes #43.
