### PR TITLE
feat(web): add competition detail route with category management UI (TKT-051)

### DIFF
--- a/apps/web/src/features/competition-detail/competition-categories-query.ts
+++ b/apps/web/src/features/competition-detail/competition-categories-query.ts
@@ -1,0 +1,23 @@
+import type { PadelApiClient } from "@padel/api-client";
+import { type QueryClient, queryOptions } from "@tanstack/react-query";
+
+export function competitionCategoriesQueryOptions(
+  apiClient: PadelApiClient,
+  competitionId: string,
+) {
+  return queryOptions({
+    queryKey: ["competitions", competitionId, "categories"],
+    queryFn: ({ signal }) =>
+      apiClient.listCategories(competitionId, { signal }),
+  });
+}
+
+export async function ensureCompetitionCategories(
+  queryClient: QueryClient,
+  apiClient: PadelApiClient,
+  competitionId: string,
+) {
+  return queryClient.ensureQueryData(
+    competitionCategoriesQueryOptions(apiClient, competitionId),
+  );
+}

--- a/apps/web/src/features/competition-detail/competition-detail-screen.tsx
+++ b/apps/web/src/features/competition-detail/competition-detail-screen.tsx
@@ -1,0 +1,384 @@
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateDescription,
+  EmptyStateEyebrow,
+  EmptyStateTitle,
+  Field,
+  InlineAlert,
+  InlineAlertDescription,
+  InlineAlertTitle,
+  Input,
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableContainer,
+  TableEmptyState,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@padel/ui";
+import { useState } from "react";
+import type { CompetitionDetailPageViewModel } from "./competition-detail-view-model.js";
+
+interface CompetitionDetailScreenProps {
+  model: CompetitionDetailPageViewModel;
+  onCreateCategory: (label: string) => Promise<void>;
+  onUpdateCategory: (id: string, label: string) => Promise<void>;
+  onDeleteCategory: (id: string) => Promise<void>;
+  isCreating: boolean;
+  isUpdating: boolean;
+  isDeleting: boolean;
+  error: string | null;
+  clearError: () => void;
+}
+
+export function CompetitionDetailScreen({
+  model,
+  onCreateCategory,
+  onUpdateCategory,
+  onDeleteCategory,
+  isCreating,
+  isUpdating,
+  isDeleting,
+  error,
+  clearError,
+}: CompetitionDetailScreenProps) {
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [newLabel, setNewLabel] = useState("");
+  const [editLabel, setEditLabel] = useState("");
+  const [editingCategory, setEditingCategory] = useState<{
+    id: string;
+    label: string;
+  } | null>(null);
+  const [deletingCategory, setDeletingCategory] = useState<{
+    id: string;
+    label: string;
+  } | null>(null);
+  const [fieldError, setFieldError] = useState<string | null>(null);
+
+  function handleCreateSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setFieldError(null);
+    if (newLabel.trim().length === 0) {
+      setFieldError("Label is required.");
+      return;
+    }
+    onCreateCategory(newLabel.trim()).then(() => {
+      setNewLabel("");
+      setCreateOpen(false);
+    });
+  }
+
+  function handleEditSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setFieldError(null);
+    if (!editingCategory || editLabel.trim().length === 0) {
+      setFieldError("Label is required.");
+      return;
+    }
+    onUpdateCategory(editingCategory.id, editLabel.trim()).then(() => {
+      setEditingCategory(null);
+      setEditLabel("");
+      setEditOpen(false);
+    });
+  }
+
+  function handleDeleteConfirm() {
+    if (!deletingCategory) return;
+    onDeleteCategory(deletingCategory.id).then(() => {
+      setDeletingCategory(null);
+      setDeleteOpen(false);
+    });
+  }
+
+  function openEdit(category: { id: string; label: string }) {
+    setEditingCategory(category);
+    setEditLabel(category.label);
+    setEditOpen(true);
+    clearError();
+    setFieldError(null);
+  }
+
+  function openDelete(category: { id: string; label: string }) {
+    setDeletingCategory(category);
+    setDeleteOpen(true);
+    clearError();
+    setFieldError(null);
+  }
+
+  function handleCreateOpenChange(open: boolean) {
+    setCreateOpen(open);
+    if (open) {
+      clearError();
+      setFieldError(null);
+      setNewLabel("");
+    }
+  }
+
+  function handleEditOpenChange(open: boolean) {
+    setEditOpen(open);
+    if (!open) {
+      setEditingCategory(null);
+      setEditLabel("");
+      setFieldError(null);
+    }
+  }
+
+  function handleDeleteOpenChange(open: boolean) {
+    setDeleteOpen(open);
+    if (!open) {
+      setDeletingCategory(null);
+      setFieldError(null);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_hsla(var(--accent)/0.75),_transparent_38%),linear-gradient(180deg,_hsl(var(--background)),_hsl(var(--secondary)/0.52))] px-4 py-8 text-foreground sm:px-6 lg:px-10">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6">
+        <section className="overflow-hidden rounded-[2rem] border border-border/70 bg-[linear-gradient(135deg,_rgba(255,255,255,0.9),_rgba(231,242,236,0.95))] p-6 shadow-[0_20px_80px_rgba(33,72,53,0.08)] sm:p-8">
+          <div className="space-y-4">
+            <p className="font-mono text-xs uppercase tracking-[0.34em] text-muted-foreground">
+              Competition detail
+            </p>
+            <h1 className="max-w-3xl font-serif text-4xl leading-tight tracking-tight sm:text-5xl">
+              Manage competition structure
+            </h1>
+            <p className="max-w-2xl text-sm leading-7 text-muted-foreground sm:text-base">
+              Configure categories that participants will register under.
+              Categories are required before opening registrations.
+            </p>
+          </div>
+        </section>
+
+        {error && (
+          <InlineAlert variant="blocked">
+            <InlineAlertTitle variant="blocked">
+              Operation failed
+            </InlineAlertTitle>
+            <InlineAlertDescription>{error}</InlineAlertDescription>
+          </InlineAlert>
+        )}
+
+        <Card className="bg-white/90">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0">
+            <div className="space-y-1">
+              <CardTitle>Categories</CardTitle>
+              <CardDescription>
+                Define the skill or format categories for this competition.
+              </CardDescription>
+            </div>
+            <Dialog open={createOpen} onOpenChange={handleCreateOpenChange}>
+              <DialogTrigger asChild>
+                <Button size="sm">Add category</Button>
+              </DialogTrigger>
+              <DialogContent>
+                <form onSubmit={handleCreateSubmit}>
+                  <DialogHeader>
+                    <DialogTitle>Create category</DialogTitle>
+                    <DialogDescription>
+                      Add a new category for participants to register under.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <CardContent className="pt-4">
+                    <Field
+                      id="new-category-label"
+                      label="Label"
+                      required
+                      error={fieldError}
+                    >
+                      <Input
+                        value={newLabel}
+                        onChange={(e) => setNewLabel(e.target.value)}
+                        placeholder="e.g. Advanced, Intermediate, Beginner"
+                        autoFocus
+                      />
+                    </Field>
+                  </CardContent>
+                  <DialogFooter>
+                    <DialogClose asChild>
+                      <Button type="button" variant="outline">
+                        Cancel
+                      </Button>
+                    </DialogClose>
+                    <Button type="submit" disabled={isCreating}>
+                      {isCreating ? "Creating..." : "Create"}
+                    </Button>
+                  </DialogFooter>
+                </form>
+              </DialogContent>
+            </Dialog>
+          </CardHeader>
+          <CardContent>
+            {!model.hasCategories ? (
+              <EmptyState variant="info">
+                <EmptyStateEyebrow>Categories</EmptyStateEyebrow>
+                <EmptyStateTitle>No categories yet</EmptyStateTitle>
+                <EmptyStateDescription>
+                  Add your first category to start structuring the competition.
+                </EmptyStateDescription>
+                <EmptyStateActions>
+                  <Dialog
+                    open={createOpen}
+                    onOpenChange={handleCreateOpenChange}
+                  >
+                    <DialogTrigger asChild>
+                      <Button>Add category</Button>
+                    </DialogTrigger>
+                  </Dialog>
+                </EmptyStateActions>
+              </EmptyState>
+            ) : (
+              <TableContainer>
+                <Table>
+                  <TableHeader>
+                    <tr>
+                      <TableHead scope="col">Label</TableHead>
+                      <TableHead scope="col">Created</TableHead>
+                      <TableHead scope="col">Updated</TableHead>
+                      <TableHead scope="col" className="w-40">
+                        Actions
+                      </TableHead>
+                    </tr>
+                  </TableHeader>
+                  <TableBody>
+                    {model.categories.map((category) => (
+                      <TableRow key={category.id} state={category.rowState}>
+                        <TableCell>
+                          <div className="space-y-1">
+                            <p className="font-medium">{category.label}</p>
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {new Date(category.createdAt).toLocaleDateString()}
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {new Date(category.updatedAt).toLocaleDateString()}
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex gap-2">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() =>
+                                openEdit({
+                                  id: category.id,
+                                  label: category.label,
+                                })
+                              }
+                            >
+                              Edit
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              onClick={() =>
+                                openDelete({
+                                  id: category.id,
+                                  label: category.label,
+                                })
+                              }
+                            >
+                              Delete
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                  <TableCaption>
+                    Categories define the participant grouping for this
+                    competition.
+                  </TableCaption>
+                </Table>
+              </TableContainer>
+            )}
+          </CardContent>
+        </Card>
+
+        <Dialog open={editOpen} onOpenChange={handleEditOpenChange}>
+          <DialogContent>
+            <form onSubmit={handleEditSubmit}>
+              <DialogHeader>
+                <DialogTitle>Edit category</DialogTitle>
+                <DialogDescription>
+                  Update the label for this category.
+                </DialogDescription>
+              </DialogHeader>
+              <CardContent className="pt-4">
+                <Field
+                  id="edit-category-label"
+                  label="Label"
+                  required
+                  error={fieldError}
+                >
+                  <Input
+                    value={editLabel}
+                    onChange={(e) => setEditLabel(e.target.value)}
+                    placeholder="Category label"
+                    autoFocus
+                  />
+                </Field>
+              </CardContent>
+              <DialogFooter>
+                <DialogClose asChild>
+                  <Button type="button" variant="outline">
+                    Cancel
+                  </Button>
+                </DialogClose>
+                <Button type="submit" disabled={isUpdating}>
+                  {isUpdating ? "Saving..." : "Save changes"}
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+
+        <Dialog open={deleteOpen} onOpenChange={handleDeleteOpenChange}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Delete category</DialogTitle>
+              <DialogDescription>
+                Are you sure you want to delete &quot;
+                {deletingCategory?.label}&quot;? This action cannot be undone.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button type="button" variant="outline">
+                  Cancel
+                </Button>
+              </DialogClose>
+              <Button
+                variant="outline"
+                disabled={isDeleting}
+                onClick={handleDeleteConfirm}
+              >
+                {isDeleting ? "Deleting..." : "Delete"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/features/competition-detail/competition-detail-screen.tsx
+++ b/apps/web/src/features/competition-detail/competition-detail-screen.tsx
@@ -1,4 +1,8 @@
 import {
+  createCategoryRequestSchema,
+  updateCategoryRequestSchema,
+} from "@padel/schemas";
+import {
   Badge,
   Button,
   Card,
@@ -35,6 +39,7 @@ import {
   TableHeader,
   TableRow,
 } from "@padel/ui";
+import { useForm } from "@tanstack/react-form";
 import { useState } from "react";
 import type { CompetitionDetailPageViewModel } from "./competition-detail-view-model.js";
 
@@ -64,8 +69,6 @@ export function CompetitionDetailScreen({
   const [createOpen, setCreateOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const [newLabel, setNewLabel] = useState("");
-  const [editLabel, setEditLabel] = useState("");
   const [editingCategory, setEditingCategory] = useState<{
     id: string;
     label: string;
@@ -74,33 +77,62 @@ export function CompetitionDetailScreen({
     id: string;
     label: string;
   } | null>(null);
-  const [fieldError, setFieldError] = useState<string | null>(null);
 
-  function handleCreateSubmit(event: React.FormEvent) {
-    event.preventDefault();
-    setFieldError(null);
-    if (newLabel.trim().length === 0) {
-      setFieldError("Label is required.");
-      return;
-    }
-    onCreateCategory(newLabel.trim()).then(() => {
-      setNewLabel("");
+  const createForm = useForm({
+    defaultValues: { label: "" },
+    validators: {
+      onChange: createCategoryRequestSchema,
+      onBlur: createCategoryRequestSchema,
+      onSubmit: createCategoryRequestSchema,
+    },
+    onSubmit: async ({ value }) => {
+      await onCreateCategory(value.label.trim());
       setCreateOpen(false);
-    });
+    },
+  });
+
+  const editForm = useForm({
+    defaultValues: { label: "" },
+    validators: {
+      onChange: updateCategoryRequestSchema,
+      onBlur: updateCategoryRequestSchema,
+      onSubmit: updateCategoryRequestSchema,
+    },
+    onSubmit: async ({ value }) => {
+      if (!editingCategory) return;
+      await onUpdateCategory(editingCategory.id, value.label.trim());
+      setEditOpen(false);
+    },
+  });
+
+  function handleCreateOpenChange(open: boolean) {
+    setCreateOpen(open);
+    if (open) {
+      clearError();
+      createForm.reset();
+    }
   }
 
-  function handleEditSubmit(event: React.FormEvent) {
-    event.preventDefault();
-    setFieldError(null);
-    if (!editingCategory || editLabel.trim().length === 0) {
-      setFieldError("Label is required.");
-      return;
-    }
-    onUpdateCategory(editingCategory.id, editLabel.trim()).then(() => {
+  function handleEditOpenChange(open: boolean) {
+    setEditOpen(open);
+    if (!open) {
       setEditingCategory(null);
-      setEditLabel("");
-      setEditOpen(false);
-    });
+      editForm.reset();
+    }
+  }
+
+  function openEdit(category: { id: string; label: string }) {
+    setEditingCategory(category);
+    editForm.reset();
+    editForm.setFieldValue("label", category.label);
+    setEditOpen(true);
+    clearError();
+  }
+
+  function openDelete(category: { id: string; label: string }) {
+    setDeletingCategory(category);
+    setDeleteOpen(true);
+    clearError();
   }
 
   function handleDeleteConfirm() {
@@ -111,44 +143,10 @@ export function CompetitionDetailScreen({
     });
   }
 
-  function openEdit(category: { id: string; label: string }) {
-    setEditingCategory(category);
-    setEditLabel(category.label);
-    setEditOpen(true);
-    clearError();
-    setFieldError(null);
-  }
-
-  function openDelete(category: { id: string; label: string }) {
-    setDeletingCategory(category);
-    setDeleteOpen(true);
-    clearError();
-    setFieldError(null);
-  }
-
-  function handleCreateOpenChange(open: boolean) {
-    setCreateOpen(open);
-    if (open) {
-      clearError();
-      setFieldError(null);
-      setNewLabel("");
-    }
-  }
-
-  function handleEditOpenChange(open: boolean) {
-    setEditOpen(open);
-    if (!open) {
-      setEditingCategory(null);
-      setEditLabel("");
-      setFieldError(null);
-    }
-  }
-
   function handleDeleteOpenChange(open: boolean) {
     setDeleteOpen(open);
     if (!open) {
       setDeletingCategory(null);
-      setFieldError(null);
     }
   }
 
@@ -192,7 +190,13 @@ export function CompetitionDetailScreen({
                 <Button size="sm">Add category</Button>
               </DialogTrigger>
               <DialogContent>
-                <form onSubmit={handleCreateSubmit}>
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    createForm.handleSubmit();
+                  }}
+                >
                   <DialogHeader>
                     <DialogTitle>Create category</DialogTitle>
                     <DialogDescription>
@@ -200,19 +204,24 @@ export function CompetitionDetailScreen({
                     </DialogDescription>
                   </DialogHeader>
                   <CardContent className="pt-4">
-                    <Field
-                      id="new-category-label"
-                      label="Label"
-                      required
-                      error={fieldError}
-                    >
-                      <Input
-                        value={newLabel}
-                        onChange={(e) => setNewLabel(e.target.value)}
-                        placeholder="e.g. Advanced, Intermediate, Beginner"
-                        autoFocus
-                      />
-                    </Field>
+                    <createForm.Field name="label">
+                      {(field) => (
+                        <Field
+                          id="new-category-label"
+                          label="Label"
+                          required
+                          error={field.state.meta.errors.join(", ")}
+                        >
+                          <Input
+                            value={field.state.value}
+                            onChange={(e) => field.handleChange(e.target.value)}
+                            onBlur={field.handleBlur}
+                            placeholder="e.g. Advanced, Intermediate, Beginner"
+                            autoFocus
+                          />
+                        </Field>
+                      )}
+                    </createForm.Field>
                   </CardContent>
                   <DialogFooter>
                     <DialogClose asChild>
@@ -317,7 +326,13 @@ export function CompetitionDetailScreen({
 
         <Dialog open={editOpen} onOpenChange={handleEditOpenChange}>
           <DialogContent>
-            <form onSubmit={handleEditSubmit}>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                editForm.handleSubmit();
+              }}
+            >
               <DialogHeader>
                 <DialogTitle>Edit category</DialogTitle>
                 <DialogDescription>
@@ -325,19 +340,24 @@ export function CompetitionDetailScreen({
                 </DialogDescription>
               </DialogHeader>
               <CardContent className="pt-4">
-                <Field
-                  id="edit-category-label"
-                  label="Label"
-                  required
-                  error={fieldError}
-                >
-                  <Input
-                    value={editLabel}
-                    onChange={(e) => setEditLabel(e.target.value)}
-                    placeholder="Category label"
-                    autoFocus
-                  />
-                </Field>
+                <editForm.Field name="label">
+                  {(field) => (
+                    <Field
+                      id="edit-category-label"
+                      label="Label"
+                      required
+                      error={field.state.meta.errors.join(", ")}
+                    >
+                      <Input
+                        value={field.state.value}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        onBlur={field.handleBlur}
+                        placeholder="Category label"
+                        autoFocus
+                      />
+                    </Field>
+                  )}
+                </editForm.Field>
               </CardContent>
               <DialogFooter>
                 <DialogClose asChild>

--- a/apps/web/src/features/competition-detail/competition-detail-view-model.ts
+++ b/apps/web/src/features/competition-detail/competition-detail-view-model.ts
@@ -1,0 +1,39 @@
+import type { CategoryCollection, CategoryResponse } from "@padel/schemas";
+import type { TableRowState } from "@padel/ui";
+
+export interface CategoryRowViewModel {
+  id: string;
+  label: string;
+  createdAt: string;
+  updatedAt: string;
+  rowState: TableRowState;
+}
+
+export interface CompetitionDetailPageViewModel {
+  competitionId: string;
+  categories: CategoryRowViewModel[];
+  hasCategories: boolean;
+}
+
+export function mapCategoriesToRowViewModel(
+  categories: CategoryCollection,
+): CategoryRowViewModel[] {
+  return categories.map((category: CategoryResponse) => ({
+    id: category.id,
+    label: category.label,
+    createdAt: category.createdAt,
+    updatedAt: category.updatedAt,
+    rowState: "default",
+  }));
+}
+
+export function mapToCompetitionDetailPageModel(
+  competitionId: string,
+  categories: CategoryCollection,
+): CompetitionDetailPageViewModel {
+  return {
+    competitionId,
+    categories: mapCategoriesToRowViewModel(categories),
+    hasCategories: categories.length > 0,
+  };
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -18,7 +18,12 @@ import {
   Input,
   Skeleton,
 } from "@padel/ui";
-import { type QueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import {
+  type QueryClient,
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
 import {
   type AnyRouter,
   type ErrorComponentProps,
@@ -35,6 +40,12 @@ import {
   useSearch,
 } from "@tanstack/react-router";
 import { useState } from "react";
+import {
+  competitionCategoriesQueryOptions,
+  ensureCompetitionCategories,
+} from "./features/competition-detail/competition-categories-query.js";
+import { CompetitionDetailScreen } from "./features/competition-detail/competition-detail-screen.js";
+import { mapToCompetitionDetailPageModel } from "./features/competition-detail/competition-detail-view-model.js";
 import { CompetitionOperationsScreen } from "./features/competition-operations/competition-operations-screen.js";
 import { competitionOverviewQueryOptions } from "./features/competition-operations/competition-overview-query.js";
 import { mapCompetitionOverviewToPageModel } from "./features/competition-operations/competition-overview-view-model.js";
@@ -107,12 +118,30 @@ const competitionOperationsRoute = createRoute({
   component: CompetitionOperationsRouteScreen,
 });
 
+const competitionDetailRoute = createRoute({
+  getParentRoute: () => authenticatedRoute,
+  path: "/competitions/$competitionId",
+  loader: ({ params, context }) =>
+    ensureCompetitionCategories(
+      context.queryClient,
+      context.apiClient,
+      params.competitionId,
+    ),
+  pendingComponent: CompetitionDetailPending,
+  pendingMs: 0,
+  errorComponent: CompetitionDetailError,
+  component: CompetitionDetailRouteScreen,
+});
+
 const routeTree = rootRoute.addChildren([
   signInRoute,
   signUpRoute,
   forgetPasswordRoute,
   resetPasswordRoute,
-  authenticatedRoute.addChildren([competitionOperationsRoute]),
+  authenticatedRoute.addChildren([
+    competitionOperationsRoute,
+    competitionDetailRoute,
+  ]),
 ]);
 
 function RootLayout() {
@@ -526,6 +555,112 @@ function CompetitionOperationsError({ error }: ErrorComponentProps) {
       <InlineAlert className="max-w-2xl bg-white/90" variant="blocked">
         <InlineAlertTitle variant="blocked">
           Competition overview could not be loaded
+        </InlineAlertTitle>
+        <InlineAlertDescription>{message}</InlineAlertDescription>
+      </InlineAlert>
+    </main>
+  );
+}
+
+function CompetitionDetailRouteScreen() {
+  const { apiClient, queryClient } = competitionDetailRoute.useRouteContext();
+  const { competitionId } = competitionDetailRoute.useParams();
+  const { data } = useSuspenseQuery(
+    competitionCategoriesQueryOptions(apiClient, competitionId),
+  );
+
+  const [error, setError] = useState<string | null>(null);
+
+  const createMutation = useMutation({
+    mutationFn: (label: string) =>
+      apiClient.createCategory(competitionId, { label }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["competitions", competitionId, "categories"],
+      });
+    },
+    onError: () => {
+      setError("Failed to create category. Please try again.");
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, label }: { id: string; label: string }) =>
+      apiClient.updateCategory(competitionId, id, { label }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["competitions", competitionId, "categories"],
+      });
+    },
+    onError: () => {
+      setError("Failed to update category. Please try again.");
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => apiClient.deleteCategory(competitionId, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["competitions", competitionId, "categories"],
+      });
+    },
+    onError: () => {
+      setError(
+        "Failed to delete category. It may be referenced by registrations.",
+      );
+    },
+  });
+
+  return (
+    <CompetitionDetailScreen
+      model={mapToCompetitionDetailPageModel(competitionId, data)}
+      onCreateCategory={async (label) => {
+        await createMutation.mutateAsync(label);
+      }}
+      onUpdateCategory={async (id, label) => {
+        await updateMutation.mutateAsync({ id, label });
+      }}
+      onDeleteCategory={async (id) => {
+        await deleteMutation.mutateAsync(id);
+      }}
+      isCreating={createMutation.isPending}
+      isUpdating={updateMutation.isPending}
+      isDeleting={deleteMutation.isPending}
+      error={error}
+      clearError={() => setError(null)}
+    />
+  );
+}
+
+function CompetitionDetailPending() {
+  return (
+    <main className="min-h-screen bg-[linear-gradient(180deg,_hsl(var(--background)),_hsl(var(--secondary)/0.52))] px-4 py-8 sm:px-6 lg:px-10">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6">
+        <div className="rounded-[2rem] border border-border/70 bg-white/80 p-6 shadow-sm sm:p-8">
+          <div className="space-y-4">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-14 w-full max-w-3xl" />
+            <Skeleton className="h-6 w-full max-w-2xl" />
+          </div>
+        </div>
+        <Skeleton className="h-40 w-full rounded-[1.5rem]" />
+        <Skeleton className="h-80 w-full rounded-[1.5rem]" />
+      </div>
+    </main>
+  );
+}
+
+function CompetitionDetailError({ error }: ErrorComponentProps) {
+  const message =
+    error instanceof Error
+      ? error.message
+      : "Unable to load competition detail.";
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-[linear-gradient(180deg,_hsl(var(--background)),_hsl(var(--secondary)/0.52))] px-6 py-12">
+      <InlineAlert className="max-w-2xl bg-white/90" variant="blocked">
+        <InlineAlertTitle variant="blocked">
+          Competition detail could not be loaded
         </InlineAlertTitle>
         <InlineAlertDescription>{message}</InlineAlertDescription>
       </InlineAlert>

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,7 +1,10 @@
 import {
   type AuthMutationResponse,
   type AuthSessionResponse,
+  type CategoryCollection,
+  type CategoryResponse,
   type CompetitionOverviewCollection,
+  type CreateCategoryRequest,
   type ForgetPasswordRequest,
   type ForgetPasswordResponse,
   type ResetPasswordRequest,
@@ -9,8 +12,11 @@ import {
   type SignInWithEmailRequest,
   type SignOutResponse,
   type SignUpWithEmailRequest,
+  type UpdateCategoryRequest,
   authMutationResponseSchema,
   authSessionResponseSchema,
+  categoryCollectionSchema,
+  categoryResponseSchema,
   competitionOverviewCollectionSchema,
   forgetPasswordResponseSchema,
   resetPasswordResponseSchema,
@@ -27,6 +33,17 @@ export const sessionPath = "/auth/session";
 export const forgetPasswordPath = "/auth/forget-password";
 export const resetPasswordPath = "/auth/reset-password";
 
+export function competitionCategoriesPath(competitionId: string) {
+  return `/competitions/${competitionId}/categories`;
+}
+
+export function competitionCategoryPath(
+  competitionId: string,
+  categoryId: string,
+) {
+  return `/competitions/${competitionId}/categories/${categoryId}`;
+}
+
 export class ApiClientError extends Error {
   constructor(
     message: string,
@@ -39,6 +56,22 @@ export class ApiClientError extends Error {
 }
 
 export interface CompetitionOverviewRequestOptions {
+  signal?: AbortSignal;
+}
+
+export interface ListCategoriesRequestOptions {
+  signal?: AbortSignal;
+}
+
+export interface CreateCategoryRequestOptions {
+  signal?: AbortSignal;
+}
+
+export interface UpdateCategoryRequestOptions {
+  signal?: AbortSignal;
+}
+
+export interface DeleteCategoryRequestOptions {
   signal?: AbortSignal;
 }
 
@@ -68,6 +101,30 @@ export interface PadelApiClient {
   ): Promise<ForgetPasswordResponse>;
 
   resetPassword(request: ResetPasswordRequest): Promise<ResetPasswordResponse>;
+
+  listCategories(
+    competitionId: string,
+    options?: ListCategoriesRequestOptions,
+  ): Promise<CategoryCollection>;
+
+  createCategory(
+    competitionId: string,
+    request: CreateCategoryRequest,
+    options?: CreateCategoryRequestOptions,
+  ): Promise<CategoryResponse>;
+
+  updateCategory(
+    competitionId: string,
+    categoryId: string,
+    request: UpdateCategoryRequest,
+    options?: UpdateCategoryRequestOptions,
+  ): Promise<CategoryResponse>;
+
+  deleteCategory(
+    competitionId: string,
+    categoryId: string,
+    options?: DeleteCategoryRequestOptions,
+  ): Promise<void>;
 }
 
 function parseResponseWithSchema<T>(
@@ -148,6 +205,38 @@ export function createApiClient({
         response.data,
         resetPasswordResponseSchema,
       );
+    },
+
+    async listCategories(competitionId, options = {}) {
+      const response = await client.get(
+        competitionCategoriesPath(competitionId),
+        { signal: options.signal },
+      );
+      return parseResponseWithSchema(response.data, categoryCollectionSchema);
+    },
+
+    async createCategory(competitionId, request, options = {}) {
+      const response = await client.post(
+        competitionCategoriesPath(competitionId),
+        request,
+        { signal: options.signal },
+      );
+      return parseResponseWithSchema(response.data, categoryResponseSchema);
+    },
+
+    async updateCategory(competitionId, categoryId, request, options = {}) {
+      const response = await client.patch(
+        competitionCategoryPath(competitionId, categoryId),
+        request,
+        { signal: options.signal },
+      );
+      return parseResponseWithSchema(response.data, categoryResponseSchema);
+    },
+
+    async deleteCategory(competitionId, categoryId, options = {}) {
+      await client.delete(competitionCategoryPath(competitionId, categoryId), {
+        signal: options.signal,
+      });
     },
   };
 }

--- a/packages/api-client/test/index.test.ts
+++ b/packages/api-client/test/index.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { ApiClientError, createApiClient } from "../src/index.js";
+import {
+  ApiClientError,
+  competitionCategoriesPath,
+  competitionCategoryPath,
+  createApiClient,
+} from "../src/index.js";
 
 describe("api-client package", () => {
   it("creates a client with default options", () => {
@@ -15,5 +20,27 @@ describe("api-client package", () => {
   it("creates a client with custom base URL", () => {
     const client = createApiClient({ apiBaseUrl: "https://padel.test/api" });
     expect(client).toBeDefined();
+  });
+
+  it("exposes category CRUD methods", () => {
+    const client = createApiClient();
+    expect(client.listCategories).toBeDefined();
+    expect(client.createCategory).toBeDefined();
+    expect(client.updateCategory).toBeDefined();
+    expect(client.deleteCategory).toBeDefined();
+  });
+});
+
+describe("category path helpers", () => {
+  it("builds list/create path for competition categories", () => {
+    expect(competitionCategoriesPath("comp-1")).toBe(
+      "/competitions/comp-1/categories",
+    );
+  });
+
+  it("builds update/delete path for a specific category", () => {
+    expect(competitionCategoryPath("comp-1", "cat-2")).toBe(
+      "/competitions/comp-1/categories/cat-2",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Add category CRUD methods (`listCategories`, `createCategory`, `updateCategory`, `deleteCategory`) to `@padel/api-client` with typed request/response contracts from `@padel/schemas`
- Create `/competitions/$competitionId` route under authenticated boundary with TanStack Query data loading and mutation hooks
- Build category management screen using `@padel/ui` primitives (Table, Dialog, Field, Input, Button, EmptyState, InlineAlert) supporting create, edit, and delete flows
- Include pending/loading states with Skeleton and error states with InlineAlert

## Affected apps/packages

- `packages/api-client` - new category CRUD methods and path helpers
- `apps/web` - new route and feature module for competition detail

## Testing

- All lint, typecheck, and test commands pass for `@padel/api-client` and `@padel/web`
- Pre-commit and pre-push hooks validated via Lefthook (lint, typecheck, test, build, boundaries)

## Linked docs

- `/docs/09-agile/product-backlog.md` (TKT-051)
- `/docs/09-agile/sprint-plan.md` (competition-structure-sprint)