### PR TITLE
feat: complete registration lifecycle end-to-end (TKT-050, TKT-052, TKT-053, TKT-054, TKT-055)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,6 +7,7 @@ import { LoggerModule } from "nestjs-pino";
 import { envValidationSchema } from "./common/config/env.validation.js";
 import { AuthModule } from "./common/modules/auth/auth.module.js";
 import { CoreModule } from "./common/modules/core/core.module.js";
+import { ApproveRegistrationUseCase } from "./competition/application/approve-registration.use-case.js";
 import { CreateCategoryUseCase } from "./competition/application/create-category.use-case.js";
 import { CreateCompetitionUseCase } from "./competition/application/create-competition.use-case.js";
 import { CreateDivisionUseCase } from "./competition/application/create-division.use-case.js";
@@ -21,6 +22,7 @@ import { CategoryRepositoryToken } from "./competition/application/ports/categor
 import { CompetitionRepositoryToken } from "./competition/application/ports/competition-repository.js";
 import { DivisionRepositoryToken } from "./competition/application/ports/division-repository.js";
 import { RegistrationRepositoryToken } from "./competition/application/ports/registration-repository.js";
+import { RejectRegistrationUseCase } from "./competition/application/reject-registration.use-case.js";
 import { UpdateCategoryUseCase } from "./competition/application/update-category.use-case.js";
 import { UpdateDivisionUseCase } from "./competition/application/update-division.use-case.js";
 import { CategoryController } from "./competition/inbound/http/category.controller.js";
@@ -123,6 +125,8 @@ import { PrismaModule } from "./prisma/prisma.module.js";
     },
     CreateRegistrationUseCase,
     ListRegistrationsUseCase,
+    ApproveRegistrationUseCase,
+    RejectRegistrationUseCase,
     PrismaRegistrationRepository,
     {
       provide: RegistrationRepositoryToken,

--- a/apps/api/src/competition/application/approve-registration.use-case.ts
+++ b/apps/api/src/competition/application/approve-registration.use-case.ts
@@ -1,0 +1,42 @@
+import { Inject, Injectable, NotFoundException } from "@nestjs/common";
+import type { RegistrationResponse } from "@padel/schemas";
+
+import {
+  type RegistrationRepository,
+  RegistrationRepositoryToken,
+} from "../application/ports/registration-repository.js";
+
+export interface ApproveRegistrationCommand {
+  registrationId: string;
+  categoryId?: string;
+  divisionId?: string;
+}
+
+@Injectable()
+export class ApproveRegistrationUseCase {
+  constructor(
+    @Inject(RegistrationRepositoryToken)
+    private readonly registrationRepository: RegistrationRepository,
+  ) {}
+
+  async execute(
+    input: ApproveRegistrationCommand,
+  ): Promise<RegistrationResponse> {
+    const existing = await this.registrationRepository.findById(
+      input.registrationId,
+    );
+
+    if (!existing) {
+      throw new NotFoundException("Registration not found.");
+    }
+
+    const approved = existing.approve({
+      categoryId: input.categoryId,
+      divisionId: input.divisionId,
+    });
+
+    await this.registrationRepository.update(approved);
+
+    return approved.toResponse();
+  }
+}

--- a/apps/api/src/competition/application/create-competition.use-case.test.ts
+++ b/apps/api/src/competition/application/create-competition.use-case.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 
+import type { Competition } from "../domain/competition.js";
 import type { CreateCompetitionCommand } from "./create-competition.command.js";
 import { CreateCompetitionUseCase } from "./create-competition.use-case.js";
 import type { CompetitionRepository } from "./ports/competition-repository.js";
 
 class FakeCompetitionRepository implements CompetitionRepository {
   created: unknown[] = [];
+  private findResult: Competition | null = null;
 
   async nextId() {
     return "competition-123";
@@ -19,6 +21,10 @@ class FakeCompetitionRepository implements CompetitionRepository {
 
   async listOverview() {
     return [];
+  }
+
+  async findById(): Promise<Competition | null> {
+    return this.findResult;
   }
 }
 

--- a/apps/api/src/competition/application/create-registration.use-case.test.ts
+++ b/apps/api/src/competition/application/create-registration.use-case.test.ts
@@ -2,14 +2,65 @@ import { describe, expect, it } from "vitest";
 
 import type { CompetitionRegistration } from "../domain/competition-registration.js";
 import { CreateRegistrationUseCase } from "./create-registration.use-case.js";
+import type { CategoryRepository } from "./ports/category-repository.js";
+import type { CompetitionRepository } from "./ports/competition-repository.js";
+import type { DivisionRepository } from "./ports/division-repository.js";
 import { FakeRegistrationRepository } from "./ports/fake-registration-repository.js";
+
+function makeFakeCompetitionRepository(overrides = {}): CompetitionRepository {
+  return {
+    nextId: async () => "comp-1",
+    create: async () => undefined,
+    listOverview: async () => [],
+    findById: async () =>
+      ({
+        toResponse: () => ({ id: "comp-1", status: "open" }),
+      }) as unknown as import("../domain/competition.js").Competition,
+    ...overrides,
+  };
+}
+
+function makeFakeCategoryRepository(overrides = {}): CategoryRepository {
+  return {
+    nextId: async () => "cat-1",
+    create: async () => undefined,
+    listByCompetitionId: async () => [],
+    findById: async () =>
+      ({
+        toResponse: () => ({ id: "cat-1", competitionId: "comp-1" }),
+      }) as unknown as import("../domain/category.js").Category,
+    update: async () => undefined,
+    delete: async () => undefined,
+    ...overrides,
+  };
+}
+
+function makeFakeDivisionRepository(overrides = {}): DivisionRepository {
+  return {
+    nextId: async () => "div-1",
+    create: async () => undefined,
+    listByCompetitionId: async () => [],
+    findById: async () =>
+      ({
+        toResponse: () => ({ id: "div-1", competitionId: "comp-1" }),
+      }) as unknown as import("../domain/division.js").Division,
+    update: async () => undefined,
+    delete: async () => undefined,
+    ...overrides,
+  };
+}
 
 describe("CreateRegistrationUseCase", () => {
   it("creates a registration for a participant", async () => {
-    const repository = new FakeRegistrationRepository({
+    const registrationRepo = new FakeRegistrationRepository({
       nextId: "reg-1",
     });
-    const useCase = new CreateRegistrationUseCase(repository);
+    const useCase = new CreateRegistrationUseCase(
+      registrationRepo,
+      makeFakeCompetitionRepository(),
+      makeFakeCategoryRepository(),
+      makeFakeDivisionRepository(),
+    );
 
     const result = await useCase.execute({
       competitionId: "comp-1",
@@ -24,16 +75,21 @@ describe("CreateRegistrationUseCase", () => {
       participantId: "user-1",
       categoryId: "cat-1",
       divisionId: "div-1",
-      status: "registered",
+      status: "pending_review",
     });
   });
 
   it("throws when participant is already registered", async () => {
-    const repository = new FakeRegistrationRepository({
+    const registrationRepo = new FakeRegistrationRepository({
       findByParticipantAndCompetitionResult:
         {} as unknown as CompetitionRegistration,
     });
-    const useCase = new CreateRegistrationUseCase(repository);
+    const useCase = new CreateRegistrationUseCase(
+      registrationRepo,
+      makeFakeCompetitionRepository(),
+      makeFakeCategoryRepository(),
+      makeFakeDivisionRepository(),
+    );
 
     await expect(
       useCase.execute({
@@ -43,5 +99,31 @@ describe("CreateRegistrationUseCase", () => {
         divisionId: "div-1",
       }),
     ).rejects.toThrow("You are already registered for this competition.");
+  });
+
+  it("throws when competition is not open", async () => {
+    const registrationRepo = new FakeRegistrationRepository();
+    const useCase = new CreateRegistrationUseCase(
+      registrationRepo,
+      makeFakeCompetitionRepository({
+        findById: async () =>
+          ({
+            toResponse: () => ({ id: "comp-1", status: "draft" }),
+          }) as unknown as import("../domain/competition.js").Competition,
+      }),
+      makeFakeCategoryRepository(),
+      makeFakeDivisionRepository(),
+    );
+
+    await expect(
+      useCase.execute({
+        competitionId: "comp-1",
+        participantId: "user-1",
+        categoryId: "cat-1",
+        divisionId: "div-1",
+      }),
+    ).rejects.toThrow(
+      "Registration is only allowed for competitions in open status.",
+    );
   });
 });

--- a/apps/api/src/competition/application/create-registration.use-case.ts
+++ b/apps/api/src/competition/application/create-registration.use-case.ts
@@ -1,7 +1,19 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, NotFoundException } from "@nestjs/common";
 import type { RegistrationResponse } from "@padel/schemas";
 
 import { CompetitionRegistration } from "../domain/competition-registration.js";
+import {
+  type CategoryRepository,
+  CategoryRepositoryToken,
+} from "./ports/category-repository.js";
+import {
+  type CompetitionRepository,
+  CompetitionRepositoryToken,
+} from "./ports/competition-repository.js";
+import {
+  type DivisionRepository,
+  DivisionRepositoryToken,
+} from "./ports/division-repository.js";
 import {
   type RegistrationRepository,
   RegistrationRepositoryToken,
@@ -19,11 +31,32 @@ export class CreateRegistrationUseCase {
   constructor(
     @Inject(RegistrationRepositoryToken)
     private readonly registrationRepository: RegistrationRepository,
+    @Inject(CompetitionRepositoryToken)
+    private readonly competitionRepository: CompetitionRepository,
+    @Inject(CategoryRepositoryToken)
+    private readonly categoryRepository: CategoryRepository,
+    @Inject(DivisionRepositoryToken)
+    private readonly divisionRepository: DivisionRepository,
   ) {}
 
   async execute(
     input: CreateRegistrationCommand,
   ): Promise<RegistrationResponse> {
+    const competition = await this.competitionRepository.findById(
+      input.competitionId,
+    );
+
+    if (!competition) {
+      throw new NotFoundException("Competition not found.");
+    }
+
+    const competitionResponse = competition.toResponse();
+    if (competitionResponse.status !== ("open" as string)) {
+      throw new Error(
+        "Registration is only allowed for competitions in open status.",
+      );
+    }
+
     const existing =
       await this.registrationRepository.findByParticipantAndCompetition(
         input.participantId,
@@ -32,6 +65,26 @@ export class CreateRegistrationUseCase {
 
     if (existing) {
       throw new Error("You are already registered for this competition.");
+    }
+
+    const category = await this.categoryRepository.findById(input.categoryId);
+    if (
+      !category ||
+      category.toResponse().competitionId !== input.competitionId
+    ) {
+      throw new NotFoundException(
+        "The selected category does not exist in this competition.",
+      );
+    }
+
+    const division = await this.divisionRepository.findById(input.divisionId);
+    if (
+      !division ||
+      division.toResponse().competitionId !== input.competitionId
+    ) {
+      throw new NotFoundException(
+        "The selected division does not exist in this competition.",
+      );
     }
 
     const id = await this.registrationRepository.nextId();

--- a/apps/api/src/competition/application/list-competition-overview.use-case.test.ts
+++ b/apps/api/src/competition/application/list-competition-overview.use-case.test.ts
@@ -25,6 +25,7 @@ describe("ListCompetitionOverviewUseCase", () => {
       nextId: async () => crypto.randomUUID(),
       create: async () => undefined,
       listOverview: async () => expected,
+      findById: async () => null,
     };
 
     const useCase = new ListCompetitionOverviewUseCase(repository);

--- a/apps/api/src/competition/application/ports/competition-repository.ts
+++ b/apps/api/src/competition/application/ports/competition-repository.ts
@@ -7,4 +7,5 @@ export interface CompetitionRepository {
   nextId(): Promise<string>;
   create(competition: Competition): Promise<void>;
   listOverview(): Promise<CompetitionOverviewCollection>;
+  findById(id: string): Promise<Competition | null>;
 }

--- a/apps/api/src/competition/application/ports/fake-registration-repository.ts
+++ b/apps/api/src/competition/application/ports/fake-registration-repository.ts
@@ -9,16 +9,19 @@ export interface FakeRegistrationRepositoryOptions {
   findByIdResult?: CompetitionRegistration | null;
   findByParticipantAndCompetitionResult?: CompetitionRegistration | null;
   createError?: Error;
+  updateError?: Error;
 }
 
 export class FakeRegistrationRepository implements RegistrationRepository {
   readonly created: unknown[] = [];
+  readonly updated: unknown[] = [];
   private store = new Map<string, CompetitionRegistration>();
   private nextIdValue: string;
   private registrationsByCompetition: Record<string, RegistrationCollection>;
   private findByIdResult: CompetitionRegistration | null;
   private findByParticipantAndCompetitionResult: CompetitionRegistration | null;
   private createError?: Error;
+  private updateError?: Error;
 
   constructor(options: FakeRegistrationRepositoryOptions = {}) {
     this.nextIdValue = options.nextId ?? "fake-registration-id";
@@ -27,6 +30,7 @@ export class FakeRegistrationRepository implements RegistrationRepository {
     this.findByParticipantAndCompetitionResult =
       options.findByParticipantAndCompetitionResult ?? null;
     this.createError = options.createError;
+    this.updateError = options.updateError;
   }
 
   seed(registration: CompetitionRegistration) {
@@ -71,6 +75,12 @@ export class FakeRegistrationRepository implements RegistrationRepository {
       }
     }
     return this.findByParticipantAndCompetitionResult;
+  }
+
+  async update(registration: CompetitionRegistration): Promise<void> {
+    if (this.updateError) throw this.updateError;
+    this.updated.push(registration.toPersistence());
+    this.store.set(registration.toResponse().id, registration);
   }
 
   private storeByCompetition(competitionId: string): RegistrationCollection {

--- a/apps/api/src/competition/application/ports/registration-repository.ts
+++ b/apps/api/src/competition/application/ports/registration-repository.ts
@@ -12,4 +12,5 @@ export interface RegistrationRepository {
     participantId: string,
     competitionId: string,
   ): Promise<CompetitionRegistration | null>;
+  update(registration: CompetitionRegistration): Promise<void>;
 }

--- a/apps/api/src/competition/application/reject-registration.use-case.ts
+++ b/apps/api/src/competition/application/reject-registration.use-case.ts
@@ -1,0 +1,29 @@
+import { Inject, Injectable, NotFoundException } from "@nestjs/common";
+import type { RegistrationResponse } from "@padel/schemas";
+
+import {
+  type RegistrationRepository,
+  RegistrationRepositoryToken,
+} from "../application/ports/registration-repository.js";
+
+@Injectable()
+export class RejectRegistrationUseCase {
+  constructor(
+    @Inject(RegistrationRepositoryToken)
+    private readonly registrationRepository: RegistrationRepository,
+  ) {}
+
+  async execute(registrationId: string): Promise<RegistrationResponse> {
+    const existing = await this.registrationRepository.findById(registrationId);
+
+    if (!existing) {
+      throw new NotFoundException("Registration not found.");
+    }
+
+    const rejected = existing.reject();
+
+    await this.registrationRepository.update(rejected);
+
+    return rejected.toResponse();
+  }
+}

--- a/apps/api/src/competition/domain/competition-registration.test.ts
+++ b/apps/api/src/competition/domain/competition-registration.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { CompetitionRegistration } from "./competition-registration.js";
 
 describe("CompetitionRegistration", () => {
-  it("creates a registration in registered status", () => {
+  it("creates a registration in pending_review status", () => {
     const registration = CompetitionRegistration.create(
       {
         competitionId: "comp-1",
@@ -23,7 +23,7 @@ describe("CompetitionRegistration", () => {
       participantId: "user-1",
       categoryId: "cat-1",
       divisionId: "div-1",
-      status: "registered",
+      status: "pending_review",
     });
   });
 
@@ -97,5 +97,79 @@ describe("CompetitionRegistration", () => {
       id: "reg-1",
       status: "approved",
     });
+  });
+
+  it("approves a pending_review registration", () => {
+    const registration = CompetitionRegistration.create(
+      {
+        competitionId: "comp-1",
+        participantId: "user-1",
+        categoryId: "cat-1",
+        divisionId: "div-1",
+      },
+      "reg-1",
+      "2026-05-04T00:00:00.000Z",
+    );
+
+    const approved = registration.approve();
+
+    expect(approved.toResponse()).toMatchObject({
+      id: "reg-1",
+      status: "approved",
+    });
+  });
+
+  it("rejects a pending_review registration", () => {
+    const registration = CompetitionRegistration.create(
+      {
+        competitionId: "comp-1",
+        participantId: "user-1",
+        categoryId: "cat-1",
+        divisionId: "div-1",
+      },
+      "reg-1",
+      "2026-05-04T00:00:00.000Z",
+    );
+
+    const rejected = registration.reject();
+
+    expect(rejected.toResponse()).toMatchObject({
+      id: "reg-1",
+      status: "rejected",
+    });
+  });
+
+  it("throws when approving a non-pending registration", () => {
+    const registration = CompetitionRegistration.restore({
+      id: "reg-1",
+      competitionId: "comp-1",
+      participantId: "user-1",
+      categoryId: "cat-1",
+      divisionId: "div-1",
+      status: "approved",
+      createdAt: "2026-05-04T00:00:00.000Z",
+      updatedAt: "2026-05-04T00:00:00.000Z",
+    });
+
+    expect(() => registration.approve()).toThrow(
+      "Only registrations in pending_review status can be approved.",
+    );
+  });
+
+  it("throws when rejecting a non-pending registration", () => {
+    const registration = CompetitionRegistration.restore({
+      id: "reg-1",
+      competitionId: "comp-1",
+      participantId: "user-1",
+      categoryId: "cat-1",
+      divisionId: "div-1",
+      status: "approved",
+      createdAt: "2026-05-04T00:00:00.000Z",
+      updatedAt: "2026-05-04T00:00:00.000Z",
+    });
+
+    expect(() => registration.reject()).toThrow(
+      "Only registrations in pending_review status can be rejected.",
+    );
   });
 });

--- a/apps/api/src/competition/domain/competition-registration.ts
+++ b/apps/api/src/competition/domain/competition-registration.ts
@@ -19,6 +19,11 @@ export interface CreateRegistrationCommand {
   divisionId: string;
 }
 
+export interface ReviewRegistrationCommand {
+  categoryId?: string;
+  divisionId?: string;
+}
+
 export class CompetitionRegistration {
   private constructor(private readonly props: RegistrationProps) {}
 
@@ -45,7 +50,7 @@ export class CompetitionRegistration {
       participantId: input.participantId,
       categoryId: input.categoryId,
       divisionId: input.divisionId,
-      status: "registered",
+      status: "pending_review",
       createdAt: now,
       updatedAt: now,
     });
@@ -55,6 +60,59 @@ export class CompetitionRegistration {
     assertRegistrationStatus(props.status);
 
     return new CompetitionRegistration(props);
+  }
+
+  approve(command?: ReviewRegistrationCommand) {
+    if (this.props.status !== "pending_review") {
+      throw new Error(
+        "Only registrations in pending_review status can be approved.",
+      );
+    }
+
+    const now = new Date().toISOString();
+
+    return new CompetitionRegistration({
+      ...this.props,
+      categoryId: command?.categoryId ?? this.props.categoryId,
+      divisionId: command?.divisionId ?? this.props.divisionId,
+      status: "approved",
+      updatedAt: now,
+    });
+  }
+
+  reject() {
+    if (this.props.status !== "pending_review") {
+      throw new Error(
+        "Only registrations in pending_review status can be rejected.",
+      );
+    }
+
+    const now = new Date().toISOString();
+
+    return new CompetitionRegistration({
+      ...this.props,
+      status: "rejected",
+      updatedAt: now,
+    });
+  }
+
+  withdraw() {
+    if (
+      this.props.status !== "pending_review" &&
+      this.props.status !== "registered"
+    ) {
+      throw new Error(
+        "Only registrations in pending_review or registered status can be withdrawn.",
+      );
+    }
+
+    const now = new Date().toISOString();
+
+    return new CompetitionRegistration({
+      ...this.props,
+      status: "withdrawn",
+      updatedAt: now,
+    });
   }
 
   toPersistence() {

--- a/apps/api/src/competition/domain/competition.ts
+++ b/apps/api/src/competition/domain/competition.ts
@@ -1,9 +1,13 @@
+import type { CreateCompetitionResponse } from "@padel/schemas";
 import type { CreateCompetitionCommand } from "../application/create-competition.command.js";
 import {
   type CompetitionFormat,
   assertCompetitionFormat,
 } from "./competition-format.js";
-import { draftCompetitionStatus } from "./competition-status.js";
+import {
+  type CompetitionStatus,
+  draftCompetitionStatus,
+} from "./competition-status.js";
 
 export interface CompetitionProps {
   id: string;
@@ -12,7 +16,7 @@ export interface CompetitionProps {
   startsAt: string;
   endsAt: string;
   ownerId: string;
-  status: typeof draftCompetitionStatus;
+  status: CompetitionStatus;
 }
 
 export class Competition {
@@ -56,11 +60,23 @@ export class Competition {
     });
   }
 
-  toPersistence() {
+  static restore(props: CompetitionProps) {
+    return new Competition(props);
+  }
+
+  toPersistence(): CompetitionProps {
     return { ...this.props };
   }
 
-  toResponse() {
-    return { ...this.props };
+  toResponse(): CreateCompetitionResponse {
+    return {
+      id: this.props.id,
+      title: this.props.title,
+      format: this.props.format,
+      startsAt: this.props.startsAt,
+      endsAt: this.props.endsAt,
+      ownerId: this.props.ownerId,
+      status: "draft",
+    };
   }
 }

--- a/apps/api/src/competition/inbound/http/registration.controller.test.ts
+++ b/apps/api/src/competition/inbound/http/registration.controller.test.ts
@@ -7,14 +7,17 @@ import request from "supertest";
 import { describe, expect, it } from "vitest";
 
 import { AuthenticatedGuard } from "../../../common/modules/auth/inbound/http/authenticated.guard.js";
+import { ApproveRegistrationUseCase } from "../../application/approve-registration.use-case.js";
 import { CreateRegistrationUseCase } from "../../application/create-registration.use-case.js";
 import { ListRegistrationsUseCase } from "../../application/list-registrations.use-case.js";
+import { RejectRegistrationUseCase } from "../../application/reject-registration.use-case.js";
 import { RegistrationController } from "./registration.controller.js";
 
 describe("RegistrationController", () => {
   const competitionId = "11111111-1111-4111-8111-111111111111";
   const categoryId = "22222222-2222-4222-8222-222222222222";
   const divisionId = "33333333-3333-4333-8333-333333333333";
+  const registrationId = "44444444-4444-4444-8444-444444444444";
 
   it("lists registrations for a competition", async () => {
     const moduleRef = await Test.createTestingModule({
@@ -34,12 +37,20 @@ describe("RegistrationController", () => {
                 participantId: "user-1",
                 categoryId,
                 divisionId,
-                status: "registered",
+                status: "pending_review",
                 createdAt: "2026-05-04T00:00:00.000Z",
                 updatedAt: "2026-05-04T00:00:00.000Z",
               },
             ],
           },
+        },
+        {
+          provide: ApproveRegistrationUseCase,
+          useValue: { execute: async () => ({}) },
+        },
+        {
+          provide: RejectRegistrationUseCase,
+          useValue: { execute: async () => ({}) },
         },
       ],
     })
@@ -88,7 +99,7 @@ describe("RegistrationController", () => {
               participantId: input.participantId,
               categoryId: input.categoryId,
               divisionId: input.divisionId,
-              status: "registered",
+              status: "pending_review",
               createdAt: "2026-05-04T00:00:00.000Z",
               updatedAt: "2026-05-04T00:00:00.000Z",
             }),
@@ -97,6 +108,14 @@ describe("RegistrationController", () => {
         {
           provide: ListRegistrationsUseCase,
           useValue: { execute: async () => [] },
+        },
+        {
+          provide: ApproveRegistrationUseCase,
+          useValue: { execute: async () => ({}) },
+        },
+        {
+          provide: RejectRegistrationUseCase,
+          useValue: { execute: async () => ({}) },
         },
       ],
     })
@@ -130,7 +149,144 @@ describe("RegistrationController", () => {
           participantId: "user-1",
           categoryId,
           divisionId,
-          status: "registered",
+          status: "pending_review",
+        });
+      });
+
+    await app.close();
+  });
+
+  it("approves a registration", async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [RegistrationController],
+      providers: [
+        {
+          provide: CreateRegistrationUseCase,
+          useValue: { execute: async () => ({}) },
+        },
+        {
+          provide: ListRegistrationsUseCase,
+          useValue: { execute: async () => [] },
+        },
+        {
+          provide: ApproveRegistrationUseCase,
+          useValue: {
+            execute: async (input: { registrationId: string }) => ({
+              id: input.registrationId,
+              competitionId,
+              participantId: "user-1",
+              categoryId,
+              divisionId,
+              status: "approved",
+              createdAt: "2026-05-04T00:00:00.000Z",
+              updatedAt: "2026-05-04T00:00:00.000Z",
+            }),
+          },
+        },
+        {
+          provide: RejectRegistrationUseCase,
+          useValue: { execute: async () => ({}) },
+        },
+      ],
+    })
+      .overrideGuard(AuthenticatedGuard)
+      .useValue({
+        canActivate(context: {
+          switchToHttp(): { getRequest(): { user?: Record<string, unknown> } };
+        }) {
+          context.switchToHttp().getRequest().user = {
+            id: "user-1",
+            email: "test@example.com",
+            name: "Test User",
+            emailVerified: true,
+            image: null,
+          };
+          return true;
+        },
+      })
+      .compile();
+
+    const app = moduleRef.createNestApplication(new ExpressAdapter());
+    await app.init();
+
+    await request(app.getHttpServer())
+      .patch(
+        `/competitions/${competitionId}/registrations/${registrationId}/approve`,
+      )
+      .send({})
+      .expect(200)
+      .expect(({ body }: { body: unknown }) => {
+        expect(body).toMatchObject({
+          id: registrationId,
+          status: "approved",
+        });
+      });
+
+    await app.close();
+  });
+
+  it("rejects a registration", async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [RegistrationController],
+      providers: [
+        {
+          provide: CreateRegistrationUseCase,
+          useValue: { execute: async () => ({}) },
+        },
+        {
+          provide: ListRegistrationsUseCase,
+          useValue: { execute: async () => [] },
+        },
+        {
+          provide: ApproveRegistrationUseCase,
+          useValue: { execute: async () => ({}) },
+        },
+        {
+          provide: RejectRegistrationUseCase,
+          useValue: {
+            execute: async (regId: string) => ({
+              id: regId,
+              competitionId,
+              participantId: "user-1",
+              categoryId,
+              divisionId,
+              status: "rejected",
+              createdAt: "2026-05-04T00:00:00.000Z",
+              updatedAt: "2026-05-04T00:00:00.000Z",
+            }),
+          },
+        },
+      ],
+    })
+      .overrideGuard(AuthenticatedGuard)
+      .useValue({
+        canActivate(context: {
+          switchToHttp(): { getRequest(): { user?: Record<string, unknown> } };
+        }) {
+          context.switchToHttp().getRequest().user = {
+            id: "user-1",
+            email: "test@example.com",
+            name: "Test User",
+            emailVerified: true,
+            image: null,
+          };
+          return true;
+        },
+      })
+      .compile();
+
+    const app = moduleRef.createNestApplication(new ExpressAdapter());
+    await app.init();
+
+    await request(app.getHttpServer())
+      .patch(
+        `/competitions/${competitionId}/registrations/${registrationId}/reject`,
+      )
+      .expect(200)
+      .expect(({ body }: { body: unknown }) => {
+        expect(body).toMatchObject({
+          id: registrationId,
+          status: "rejected",
         });
       });
 
@@ -148,6 +304,14 @@ describe("RegistrationController", () => {
         {
           provide: ListRegistrationsUseCase,
           useValue: { execute: async () => [] },
+        },
+        {
+          provide: ApproveRegistrationUseCase,
+          useValue: { execute: async () => ({}) },
+        },
+        {
+          provide: RejectRegistrationUseCase,
+          useValue: { execute: async () => ({}) },
         },
       ],
     })

--- a/apps/api/src/competition/inbound/http/registration.controller.ts
+++ b/apps/api/src/competition/inbound/http/registration.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpStatus,
   Inject,
   Param,
+  Patch,
   Post,
   UseGuards,
 } from "@nestjs/common";
@@ -13,13 +14,16 @@ import {
   createRegistrationRequestSchema,
   registrationCollectionSchema,
   registrationResponseSchema,
+  reviewRegistrationRequestSchema,
 } from "@padel/schemas";
 
 import type { AuthenticatedUser } from "../../../common/modules/auth/application/ports/auth-gateway.port.js";
 import { AuthenticatedGuard } from "../../../common/modules/auth/inbound/http/authenticated.guard.js";
 import { CurrentUser } from "../../../common/modules/auth/inbound/http/current-user.decorator.js";
+import { ApproveRegistrationUseCase } from "../../application/approve-registration.use-case.js";
 import { CreateRegistrationUseCase } from "../../application/create-registration.use-case.js";
 import { ListRegistrationsUseCase } from "../../application/list-registrations.use-case.js";
+import { RejectRegistrationUseCase } from "../../application/reject-registration.use-case.js";
 
 @Controller("competitions/:competitionId/registrations")
 export class RegistrationController {
@@ -28,6 +32,10 @@ export class RegistrationController {
     private readonly createRegistrationUseCase: CreateRegistrationUseCase,
     @Inject(ListRegistrationsUseCase)
     private readonly listRegistrationsUseCase: ListRegistrationsUseCase,
+    @Inject(ApproveRegistrationUseCase)
+    private readonly approveRegistrationUseCase: ApproveRegistrationUseCase,
+    @Inject(RejectRegistrationUseCase)
+    private readonly rejectRegistrationUseCase: RejectRegistrationUseCase,
   ) {}
 
   @Get()
@@ -62,6 +70,36 @@ export class RegistrationController {
       categoryId: request.categoryId,
       divisionId: request.divisionId,
     });
+
+    return registrationResponseSchema.parse(response);
+  }
+
+  @Patch(":registrationId/approve")
+  @UseGuards(AuthenticatedGuard)
+  async approveRegistration(
+    @Param("competitionId") _competitionId: string,
+    @Param("registrationId") registrationId: string,
+    @Body() body: unknown,
+  ) {
+    const request = reviewRegistrationRequestSchema.parse(body);
+
+    const response = await this.approveRegistrationUseCase.execute({
+      registrationId,
+      categoryId: request.categoryId,
+      divisionId: request.divisionId,
+    });
+
+    return registrationResponseSchema.parse(response);
+  }
+
+  @Patch(":registrationId/reject")
+  @UseGuards(AuthenticatedGuard)
+  async rejectRegistration(
+    @Param("competitionId") _competitionId: string,
+    @Param("registrationId") registrationId: string,
+  ) {
+    const response =
+      await this.rejectRegistrationUseCase.execute(registrationId);
 
     return registrationResponseSchema.parse(response);
   }

--- a/apps/api/src/competition/outbound/persistence/prisma-competition.repository.ts
+++ b/apps/api/src/competition/outbound/persistence/prisma-competition.repository.ts
@@ -3,7 +3,8 @@ import { competitionOverviewCollectionSchema } from "@padel/schemas";
 
 import { PrismaService } from "../../../prisma/prisma.service.js";
 import type { CompetitionRepository } from "../../application/ports/competition-repository.js";
-import type { Competition } from "../../domain/competition.js";
+import type { CompetitionStatus } from "../../domain/competition-status.js";
+import { Competition } from "../../domain/competition.js";
 import { mapCompetitionOverviewRow } from "./competition-overview.mapper.js";
 
 @Injectable()
@@ -71,5 +72,25 @@ export class PrismaCompetitionRepository implements CompetitionRepository {
         })
         .filter((row): row is NonNullable<typeof row> => row !== null),
     );
+  }
+
+  async findById(id: string) {
+    const row = await this.prisma.competition.findUnique({
+      where: { id },
+    });
+
+    if (!row) {
+      return null;
+    }
+
+    return Competition.restore({
+      id: row.id,
+      title: row.title,
+      format: row.format === "round_robin" ? "round-robin" : row.format,
+      startsAt: row.startsAt.toISOString(),
+      endsAt: row.endsAt.toISOString(),
+      ownerId: row.ownerId,
+      status: row.status as CompetitionStatus,
+    });
   }
 }

--- a/apps/api/src/competition/outbound/persistence/prisma-registration.repository.ts
+++ b/apps/api/src/competition/outbound/persistence/prisma-registration.repository.ts
@@ -97,4 +97,18 @@ export class PrismaRegistrationRepository implements RegistrationRepository {
       updatedAt: row.updatedAt.toISOString(),
     });
   }
+
+  async update(registration: CompetitionRegistration) {
+    const row = registration.toPersistence();
+
+    await this.prisma.registration.update({
+      where: { id: row.id },
+      data: {
+        status: row.status,
+        categoryId: row.categoryId,
+        divisionId: row.divisionId,
+        updatedAt: row.updatedAt,
+      },
+    });
+  }
 }

--- a/apps/web/src/features/competition-detail/competition-detail-screen.tsx
+++ b/apps/web/src/features/competition-detail/competition-detail-screen.tsx
@@ -1,6 +1,10 @@
 import {
   createCategoryRequestSchema,
+  createDivisionRequestSchema,
+  createRegistrationRequestSchema,
+  reviewRegistrationRequestSchema,
   updateCategoryRequestSchema,
+  updateDivisionRequestSchema,
 } from "@padel/schemas";
 import {
   Badge,
@@ -29,6 +33,7 @@ import {
   InlineAlertDescription,
   InlineAlertTitle,
   Input,
+  Select,
   Table,
   TableBody,
   TableCaption,
@@ -48,9 +53,24 @@ interface CompetitionDetailScreenProps {
   onCreateCategory: (label: string) => Promise<void>;
   onUpdateCategory: (id: string, label: string) => Promise<void>;
   onDeleteCategory: (id: string) => Promise<void>;
+  onCreateDivision: (name: string) => Promise<void>;
+  onUpdateDivision: (id: string, name: string) => Promise<void>;
+  onDeleteDivision: (id: string) => Promise<void>;
+  onCreateRegistration: (
+    categoryId: string,
+    divisionId: string,
+  ) => Promise<void>;
+  onApproveRegistration: (
+    registrationId: string,
+    categoryId?: string,
+    divisionId?: string,
+  ) => Promise<void>;
+  onRejectRegistration: (registrationId: string) => Promise<void>;
   isCreating: boolean;
   isUpdating: boolean;
   isDeleting: boolean;
+  isRegistering: boolean;
+  isReviewing: boolean;
   error: string | null;
   clearError: () => void;
 }
@@ -60,15 +80,23 @@ export function CompetitionDetailScreen({
   onCreateCategory,
   onUpdateCategory,
   onDeleteCategory,
+  onCreateDivision,
+  onUpdateDivision,
+  onDeleteDivision,
+  onCreateRegistration,
+  onApproveRegistration,
+  onRejectRegistration,
   isCreating,
   isUpdating,
   isDeleting,
+  isRegistering,
+  isReviewing,
   error,
   clearError,
 }: CompetitionDetailScreenProps) {
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
-  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [createCategoryOpen, setCreateCategoryOpen] = useState(false);
+  const [editCategoryOpen, setEditCategoryOpen] = useState(false);
+  const [deleteCategoryOpen, setDeleteCategoryOpen] = useState(false);
   const [editingCategory, setEditingCategory] = useState<{
     id: string;
     label: string;
@@ -78,7 +106,31 @@ export function CompetitionDetailScreen({
     label: string;
   } | null>(null);
 
-  const createForm = useForm({
+  const [createDivisionOpen, setCreateDivisionOpen] = useState(false);
+  const [editDivisionOpen, setEditDivisionOpen] = useState(false);
+  const [deleteDivisionOpen, setDeleteDivisionOpen] = useState(false);
+  const [editingDivision, setEditingDivision] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+  const [deletingDivision, setDeletingDivision] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+
+  const [registerOpen, setRegisterOpen] = useState(false);
+  const [approveOpen, setApproveOpen] = useState(false);
+  const [rejectOpen, setRejectOpen] = useState(false);
+  const [approvingRegistration, setApprovingRegistration] = useState<{
+    id: string;
+    categoryId: string;
+    divisionId: string;
+  } | null>(null);
+  const [rejectingRegistration, setRejectingRegistration] = useState<{
+    id: string;
+  } | null>(null);
+
+  const createCategoryForm = useForm({
     defaultValues: { label: "" },
     validators: {
       onChange: createCategoryRequestSchema,
@@ -87,11 +139,11 @@ export function CompetitionDetailScreen({
     },
     onSubmit: async ({ value }) => {
       await onCreateCategory(value.label.trim());
-      setCreateOpen(false);
+      setCreateCategoryOpen(false);
     },
   });
 
-  const editForm = useForm({
+  const editCategoryForm = useForm({
     defaultValues: { label: "" },
     validators: {
       onChange: updateCategoryRequestSchema,
@@ -101,53 +153,215 @@ export function CompetitionDetailScreen({
     onSubmit: async ({ value }) => {
       if (!editingCategory) return;
       await onUpdateCategory(editingCategory.id, value.label.trim());
-      setEditOpen(false);
+      setEditCategoryOpen(false);
     },
   });
 
-  function handleCreateOpenChange(open: boolean) {
-    setCreateOpen(open);
+  const createDivisionForm = useForm({
+    defaultValues: { name: "" },
+    validators: {
+      onChange: createDivisionRequestSchema,
+      onBlur: createDivisionRequestSchema,
+      onSubmit: createDivisionRequestSchema,
+    },
+    onSubmit: async ({ value }) => {
+      await onCreateDivision(value.name.trim());
+      setCreateDivisionOpen(false);
+    },
+  });
+
+  const editDivisionForm = useForm({
+    defaultValues: { name: "" },
+    validators: {
+      onChange: updateDivisionRequestSchema,
+      onBlur: updateDivisionRequestSchema,
+      onSubmit: updateDivisionRequestSchema,
+    },
+    onSubmit: async ({ value }) => {
+      if (!editingDivision) return;
+      await onUpdateDivision(editingDivision.id, value.name.trim());
+      setEditDivisionOpen(false);
+    },
+  });
+
+  const registrationForm = useForm({
+    defaultValues: { categoryId: "", divisionId: "" },
+    validators: {
+      onChange: createRegistrationRequestSchema,
+      onBlur: createRegistrationRequestSchema,
+      onSubmit: createRegistrationRequestSchema,
+    },
+    onSubmit: async ({ value }) => {
+      await onCreateRegistration(value.categoryId, value.divisionId);
+      setRegisterOpen(false);
+    },
+  });
+
+  const approveForm = useForm({
+    defaultValues: { categoryId: "", divisionId: "" },
+    onSubmit: async ({ value }) => {
+      if (!approvingRegistration) return;
+      await onApproveRegistration(
+        approvingRegistration.id,
+        value.categoryId || undefined,
+        value.divisionId || undefined,
+      );
+      setApproveOpen(false);
+    },
+  });
+
+  function handleCreateCategoryOpenChange(open: boolean) {
+    setCreateCategoryOpen(open);
     if (open) {
       clearError();
-      createForm.reset();
+      createCategoryForm.reset();
     }
   }
 
-  function handleEditOpenChange(open: boolean) {
-    setEditOpen(open);
+  function handleEditCategoryOpenChange(open: boolean) {
+    setEditCategoryOpen(open);
     if (!open) {
       setEditingCategory(null);
-      editForm.reset();
+      editCategoryForm.reset();
     }
   }
 
-  function openEdit(category: { id: string; label: string }) {
+  function openEditCategory(category: { id: string; label: string }) {
     setEditingCategory(category);
-    editForm.reset();
-    editForm.setFieldValue("label", category.label);
-    setEditOpen(true);
+    editCategoryForm.reset();
+    editCategoryForm.setFieldValue("label", category.label);
+    setEditCategoryOpen(true);
     clearError();
   }
 
-  function openDelete(category: { id: string; label: string }) {
+  function openDeleteCategory(category: { id: string; label: string }) {
     setDeletingCategory(category);
-    setDeleteOpen(true);
+    setDeleteCategoryOpen(true);
     clearError();
   }
 
-  function handleDeleteConfirm() {
+  function handleDeleteCategoryConfirm() {
     if (!deletingCategory) return;
     onDeleteCategory(deletingCategory.id).then(() => {
       setDeletingCategory(null);
-      setDeleteOpen(false);
+      setDeleteCategoryOpen(false);
     });
   }
 
-  function handleDeleteOpenChange(open: boolean) {
-    setDeleteOpen(open);
+  function handleDeleteCategoryOpenChange(open: boolean) {
+    setDeleteCategoryOpen(open);
     if (!open) {
       setDeletingCategory(null);
     }
+  }
+
+  function handleCreateDivisionOpenChange(open: boolean) {
+    setCreateDivisionOpen(open);
+    if (open) {
+      clearError();
+      createDivisionForm.reset();
+    }
+  }
+
+  function handleEditDivisionOpenChange(open: boolean) {
+    setEditDivisionOpen(open);
+    if (!open) {
+      setEditingDivision(null);
+      editDivisionForm.reset();
+    }
+  }
+
+  function openEditDivision(division: { id: string; name: string }) {
+    setEditingDivision(division);
+    editDivisionForm.reset();
+    editDivisionForm.setFieldValue("name", division.name);
+    setEditDivisionOpen(true);
+    clearError();
+  }
+
+  function openDeleteDivision(division: { id: string; name: string }) {
+    setDeletingDivision(division);
+    setDeleteDivisionOpen(true);
+    clearError();
+  }
+
+  function handleDeleteDivisionConfirm() {
+    if (!deletingDivision) return;
+    onDeleteDivision(deletingDivision.id).then(() => {
+      setDeletingDivision(null);
+      setDeleteDivisionOpen(false);
+    });
+  }
+
+  function handleDeleteDivisionOpenChange(open: boolean) {
+    setDeleteDivisionOpen(open);
+    if (!open) {
+      setDeletingDivision(null);
+    }
+  }
+
+  function handleRegisterOpenChange(open: boolean) {
+    setRegisterOpen(open);
+    if (open) {
+      clearError();
+      registrationForm.reset();
+    }
+  }
+
+  function openApprove(registration: {
+    id: string;
+    categoryId: string;
+    divisionId: string;
+  }) {
+    setApprovingRegistration(registration);
+    approveForm.reset();
+    approveForm.setFieldValue("categoryId", registration.categoryId);
+    approveForm.setFieldValue("divisionId", registration.divisionId);
+    setApproveOpen(true);
+    clearError();
+  }
+
+  function openReject(registration: { id: string }) {
+    setRejectingRegistration(registration);
+    setRejectOpen(true);
+    clearError();
+  }
+
+  function handleRejectConfirm() {
+    if (!rejectingRegistration) return;
+    onRejectRegistration(rejectingRegistration.id).then(() => {
+      setRejectingRegistration(null);
+      setRejectOpen(false);
+    });
+  }
+
+  function handleRejectOpenChange(open: boolean) {
+    setRejectOpen(open);
+    if (!open) {
+      setRejectingRegistration(null);
+    }
+  }
+
+  function getStatusBadge(status: string) {
+    const variantMap: Record<string, "default" | "secondary" | "outline"> = {
+      pending_review: "default",
+      approved: "default",
+      rejected: "secondary",
+      withdrawn: "outline",
+      registered: "outline",
+    };
+    const labelMap: Record<string, string> = {
+      pending_review: "Pending Review",
+      approved: "Approved",
+      rejected: "Rejected",
+      withdrawn: "Withdrawn",
+      registered: "Registered",
+    };
+    return (
+      <Badge variant={variantMap[status] ?? "default"}>
+        {labelMap[status] ?? status}
+      </Badge>
+    );
   }
 
   return (
@@ -162,8 +376,8 @@ export function CompetitionDetailScreen({
               Manage competition structure
             </h1>
             <p className="max-w-2xl text-sm leading-7 text-muted-foreground sm:text-base">
-              Configure categories that participants will register under.
-              Categories are required before opening registrations.
+              Configure categories and divisions, manage registrations, and
+              review participant submissions.
             </p>
           </div>
         </section>
@@ -177,6 +391,173 @@ export function CompetitionDetailScreen({
           </InlineAlert>
         )}
 
+        {/* Registration Section */}
+        <Card className="bg-white/90">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0">
+            <div className="space-y-1">
+              <CardTitle>Register for Competition</CardTitle>
+              <CardDescription>
+                Submit your registration to participate in this competition.
+              </CardDescription>
+            </div>
+            <Dialog open={registerOpen} onOpenChange={handleRegisterOpenChange}>
+              <DialogTrigger asChild>
+                <Button size="sm">Register</Button>
+              </DialogTrigger>
+              <DialogContent>
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    registrationForm.handleSubmit();
+                  }}
+                >
+                  <DialogHeader>
+                    <DialogTitle>Register for competition</DialogTitle>
+                    <DialogDescription>
+                      Select your category and division to register.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <CardContent className="space-y-4 pt-4">
+                    <registrationForm.Field name="categoryId">
+                      {(field) => (
+                        <Field
+                          id="registration-category"
+                          label="Category"
+                          required
+                          error={getFieldError(field.state.meta.errors)}
+                        >
+                          <Select
+                            value={field.state.value}
+                            onValueChange={(value) =>
+                              field.handleChange(value ?? "")
+                            }
+                          >
+                            <option value="">Select a category</option>
+                            {model.categories.map((cat) => (
+                              <option key={cat.id} value={cat.id}>
+                                {cat.label}
+                              </option>
+                            ))}
+                          </Select>
+                        </Field>
+                      )}
+                    </registrationForm.Field>
+                    <registrationForm.Field name="divisionId">
+                      {(field) => (
+                        <Field
+                          id="registration-division"
+                          label="Division"
+                          required
+                          error={getFieldError(field.state.meta.errors)}
+                        >
+                          <Select
+                            value={field.state.value}
+                            onValueChange={(value) =>
+                              field.handleChange(value ?? "")
+                            }
+                          >
+                            <option value="">Select a division</option>
+                            {model.divisions.map((div) => (
+                              <option key={div.id} value={div.id}>
+                                {div.name}
+                              </option>
+                            ))}
+                          </Select>
+                        </Field>
+                      )}
+                    </registrationForm.Field>
+                  </CardContent>
+                  <DialogFooter>
+                    <DialogClose asChild>
+                      <Button type="button" variant="outline">
+                        Cancel
+                      </Button>
+                    </DialogClose>
+                    <Button type="submit" disabled={isRegistering}>
+                      {isRegistering ? "Registering..." : "Register"}
+                    </Button>
+                  </DialogFooter>
+                </form>
+              </DialogContent>
+            </Dialog>
+          </CardHeader>
+        </Card>
+
+        {/* Pending Registrations Review */}
+        {model.hasPendingRegistrations && (
+          <Card className="bg-white/90">
+            <CardHeader>
+              <CardTitle>Pending Registrations</CardTitle>
+              <CardDescription>
+                Review and approve or reject pending registrations.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <TableContainer>
+                <Table>
+                  <TableHeader>
+                    <tr>
+                      <TableHead scope="col">Participant</TableHead>
+                      <TableHead scope="col">Category</TableHead>
+                      <TableHead scope="col">Division</TableHead>
+                      <TableHead scope="col">Status</TableHead>
+                      <TableHead scope="col" className="w-48">
+                        Actions
+                      </TableHead>
+                    </tr>
+                  </TableHeader>
+                  <TableBody>
+                    {model.pendingRegistrations.map((reg) => (
+                      <TableRow key={reg.id} state={reg.rowState}>
+                        <TableCell>
+                          <p className="font-medium">
+                            {reg.participantId.slice(0, 8)}...
+                          </p>
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {model.categories.find((c) => c.id === reg.categoryId)
+                            ?.label ?? "Unknown"}
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {model.divisions.find((d) => d.id === reg.divisionId)
+                            ?.name ?? "Unknown"}
+                        </TableCell>
+                        <TableCell>{getStatusBadge(reg.status)}</TableCell>
+                        <TableCell>
+                          <div className="flex gap-2">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() =>
+                                openApprove({
+                                  id: reg.id,
+                                  categoryId: reg.categoryId,
+                                  divisionId: reg.divisionId,
+                                })
+                              }
+                            >
+                              Approve
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              onClick={() => openReject({ id: reg.id })}
+                            >
+                              Reject
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Categories Section */}
         <Card className="bg-white/90">
           <CardHeader className="flex flex-row items-center justify-between space-y-0">
             <div className="space-y-1">
@@ -185,7 +566,10 @@ export function CompetitionDetailScreen({
                 Define the skill or format categories for this competition.
               </CardDescription>
             </div>
-            <Dialog open={createOpen} onOpenChange={handleCreateOpenChange}>
+            <Dialog
+              open={createCategoryOpen}
+              onOpenChange={handleCreateCategoryOpenChange}
+            >
               <DialogTrigger asChild>
                 <Button size="sm">Add category</Button>
               </DialogTrigger>
@@ -194,7 +578,7 @@ export function CompetitionDetailScreen({
                   onSubmit={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
-                    createForm.handleSubmit();
+                    createCategoryForm.handleSubmit();
                   }}
                 >
                   <DialogHeader>
@@ -204,24 +588,23 @@ export function CompetitionDetailScreen({
                     </DialogDescription>
                   </DialogHeader>
                   <CardContent className="pt-4">
-                    <createForm.Field name="label">
+                    <createCategoryForm.Field name="label">
                       {(field) => (
                         <Field
                           id="new-category-label"
                           label="Label"
                           required
-                          error={field.state.meta.errors.join(", ")}
+                          error={getFieldError(field.state.meta.errors)}
                         >
                           <Input
                             value={field.state.value}
                             onChange={(e) => field.handleChange(e.target.value)}
-                            onBlur={field.handleBlur}
                             placeholder="e.g. Advanced, Intermediate, Beginner"
                             autoFocus
                           />
                         </Field>
                       )}
-                    </createForm.Field>
+                    </createCategoryForm.Field>
                   </CardContent>
                   <DialogFooter>
                     <DialogClose asChild>
@@ -247,8 +630,8 @@ export function CompetitionDetailScreen({
                 </EmptyStateDescription>
                 <EmptyStateActions>
                   <Dialog
-                    open={createOpen}
-                    onOpenChange={handleCreateOpenChange}
+                    open={createCategoryOpen}
+                    onOpenChange={handleCreateCategoryOpenChange}
                   >
                     <DialogTrigger asChild>
                       <Button>Add category</Button>
@@ -289,7 +672,7 @@ export function CompetitionDetailScreen({
                               size="sm"
                               variant="outline"
                               onClick={() =>
-                                openEdit({
+                                openEditCategory({
                                   id: category.id,
                                   label: category.label,
                                 })
@@ -301,7 +684,7 @@ export function CompetitionDetailScreen({
                               size="sm"
                               variant="ghost"
                               onClick={() =>
-                                openDelete({
+                                openDeleteCategory({
                                   id: category.id,
                                   label: category.label,
                                 })
@@ -324,13 +707,168 @@ export function CompetitionDetailScreen({
           </CardContent>
         </Card>
 
-        <Dialog open={editOpen} onOpenChange={handleEditOpenChange}>
+        {/* Divisions Section */}
+        <Card className="bg-white/90">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0">
+            <div className="space-y-1">
+              <CardTitle>Divisions</CardTitle>
+              <CardDescription>
+                Define the divisions (e.g., Men, Women, Mixed) for this
+                competition.
+              </CardDescription>
+            </div>
+            <Dialog
+              open={createDivisionOpen}
+              onOpenChange={handleCreateDivisionOpenChange}
+            >
+              <DialogTrigger asChild>
+                <Button size="sm">Add division</Button>
+              </DialogTrigger>
+              <DialogContent>
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    createDivisionForm.handleSubmit();
+                  }}
+                >
+                  <DialogHeader>
+                    <DialogTitle>Create division</DialogTitle>
+                    <DialogDescription>
+                      Add a new division for participants to register under.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <CardContent className="pt-4">
+                    <createDivisionForm.Field name="name">
+                      {(field) => (
+                        <Field
+                          id="new-division-name"
+                          label="Name"
+                          required
+                          error={getFieldError(field.state.meta.errors)}
+                        >
+                          <Input
+                            value={field.state.value}
+                            onChange={(e) => field.handleChange(e.target.value)}
+                            placeholder="e.g. Men, Women, Mixed"
+                            autoFocus
+                          />
+                        </Field>
+                      )}
+                    </createDivisionForm.Field>
+                  </CardContent>
+                  <DialogFooter>
+                    <DialogClose asChild>
+                      <Button type="button" variant="outline">
+                        Cancel
+                      </Button>
+                    </DialogClose>
+                    <Button type="submit" disabled={isCreating}>
+                      {isCreating ? "Creating..." : "Create"}
+                    </Button>
+                  </DialogFooter>
+                </form>
+              </DialogContent>
+            </Dialog>
+          </CardHeader>
+          <CardContent>
+            {!model.hasDivisions ? (
+              <EmptyState variant="info">
+                <EmptyStateEyebrow>Divisions</EmptyStateEyebrow>
+                <EmptyStateTitle>No divisions yet</EmptyStateTitle>
+                <EmptyStateDescription>
+                  Add your first division to start structuring the competition.
+                </EmptyStateDescription>
+                <EmptyStateActions>
+                  <Dialog
+                    open={createDivisionOpen}
+                    onOpenChange={handleCreateDivisionOpenChange}
+                  >
+                    <DialogTrigger asChild>
+                      <Button>Add division</Button>
+                    </DialogTrigger>
+                  </Dialog>
+                </EmptyStateActions>
+              </EmptyState>
+            ) : (
+              <TableContainer>
+                <Table>
+                  <TableHeader>
+                    <tr>
+                      <TableHead scope="col">Name</TableHead>
+                      <TableHead scope="col">Created</TableHead>
+                      <TableHead scope="col">Updated</TableHead>
+                      <TableHead scope="col" className="w-40">
+                        Actions
+                      </TableHead>
+                    </tr>
+                  </TableHeader>
+                  <TableBody>
+                    {model.divisions.map((division) => (
+                      <TableRow key={division.id} state={division.rowState}>
+                        <TableCell>
+                          <div className="space-y-1">
+                            <p className="font-medium">{division.name}</p>
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {new Date(division.createdAt).toLocaleDateString()}
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {new Date(division.updatedAt).toLocaleDateString()}
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex gap-2">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() =>
+                                openEditDivision({
+                                  id: division.id,
+                                  name: division.name,
+                                })
+                              }
+                            >
+                              Edit
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              onClick={() =>
+                                openDeleteDivision({
+                                  id: division.id,
+                                  name: division.name,
+                                })
+                              }
+                            >
+                              Delete
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                  <TableCaption>
+                    Divisions define the participant segmentation for this
+                    competition.
+                  </TableCaption>
+                </Table>
+              </TableContainer>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Edit Category Dialog */}
+        <Dialog
+          open={editCategoryOpen}
+          onOpenChange={handleEditCategoryOpenChange}
+        >
           <DialogContent>
             <form
               onSubmit={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                editForm.handleSubmit();
+                editCategoryForm.handleSubmit();
               }}
             >
               <DialogHeader>
@@ -340,24 +878,23 @@ export function CompetitionDetailScreen({
                 </DialogDescription>
               </DialogHeader>
               <CardContent className="pt-4">
-                <editForm.Field name="label">
+                <editCategoryForm.Field name="label">
                   {(field) => (
                     <Field
                       id="edit-category-label"
                       label="Label"
                       required
-                      error={field.state.meta.errors.join(", ")}
+                      error={getFieldError(field.state.meta.errors)}
                     >
                       <Input
                         value={field.state.value}
                         onChange={(e) => field.handleChange(e.target.value)}
-                        onBlur={field.handleBlur}
                         placeholder="Category label"
                         autoFocus
                       />
                     </Field>
                   )}
-                </editForm.Field>
+                </editCategoryForm.Field>
               </CardContent>
               <DialogFooter>
                 <DialogClose asChild>
@@ -373,7 +910,11 @@ export function CompetitionDetailScreen({
           </DialogContent>
         </Dialog>
 
-        <Dialog open={deleteOpen} onOpenChange={handleDeleteOpenChange}>
+        {/* Delete Category Dialog */}
+        <Dialog
+          open={deleteCategoryOpen}
+          onOpenChange={handleDeleteCategoryOpenChange}
+        >
           <DialogContent>
             <DialogHeader>
               <DialogTitle>Delete category</DialogTitle>
@@ -391,9 +932,202 @@ export function CompetitionDetailScreen({
               <Button
                 variant="outline"
                 disabled={isDeleting}
-                onClick={handleDeleteConfirm}
+                onClick={handleDeleteCategoryConfirm}
               >
                 {isDeleting ? "Deleting..." : "Delete"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        {/* Edit Division Dialog */}
+        <Dialog
+          open={editDivisionOpen}
+          onOpenChange={handleEditDivisionOpenChange}
+        >
+          <DialogContent>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                editDivisionForm.handleSubmit();
+              }}
+            >
+              <DialogHeader>
+                <DialogTitle>Edit division</DialogTitle>
+                <DialogDescription>
+                  Update the name for this division.
+                </DialogDescription>
+              </DialogHeader>
+              <CardContent className="pt-4">
+                <editDivisionForm.Field name="name">
+                  {(field) => (
+                    <Field
+                      id="edit-division-name"
+                      label="Name"
+                      required
+                      error={getFieldError(field.state.meta.errors)}
+                    >
+                      <Input
+                        value={field.state.value}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        placeholder="Division name"
+                        autoFocus
+                      />
+                    </Field>
+                  )}
+                </editDivisionForm.Field>
+              </CardContent>
+              <DialogFooter>
+                <DialogClose asChild>
+                  <Button type="button" variant="outline">
+                    Cancel
+                  </Button>
+                </DialogClose>
+                <Button type="submit" disabled={isUpdating}>
+                  {isUpdating ? "Saving..." : "Save changes"}
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+
+        {/* Delete Division Dialog */}
+        <Dialog
+          open={deleteDivisionOpen}
+          onOpenChange={handleDeleteDivisionOpenChange}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Delete division</DialogTitle>
+              <DialogDescription>
+                Are you sure you want to delete &quot;
+                {deletingDivision?.name}&quot;? This action cannot be undone.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button type="button" variant="outline">
+                  Cancel
+                </Button>
+              </DialogClose>
+              <Button
+                variant="outline"
+                disabled={isDeleting}
+                onClick={handleDeleteDivisionConfirm}
+              >
+                {isDeleting ? "Deleting..." : "Delete"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        {/* Approve Registration Dialog */}
+        <Dialog
+          open={approveOpen}
+          onOpenChange={(open) => {
+            setApproveOpen(open);
+            if (!open) setApprovingRegistration(null);
+          }}
+        >
+          <DialogContent>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                approveForm.handleSubmit();
+              }}
+            >
+              <DialogHeader>
+                <DialogTitle>Approve registration</DialogTitle>
+                <DialogDescription>
+                  Optionally adjust the category or division before approving.
+                </DialogDescription>
+              </DialogHeader>
+              <CardContent className="space-y-4 pt-4">
+                <approveForm.Field name="categoryId">
+                  {(field) => (
+                    <Field
+                      id="approve-category"
+                      label="Category (optional)"
+                      error={getFieldError(field.state.meta.errors)}
+                    >
+                      <Select
+                        value={field.state.value}
+                        onValueChange={(value) =>
+                          field.handleChange(value ?? "")
+                        }
+                      >
+                        <option value="">Keep current</option>
+                        {model.categories.map((cat) => (
+                          <option key={cat.id} value={cat.id}>
+                            {cat.label}
+                          </option>
+                        ))}
+                      </Select>
+                    </Field>
+                  )}
+                </approveForm.Field>
+                <approveForm.Field name="divisionId">
+                  {(field) => (
+                    <Field
+                      id="approve-division"
+                      label="Division (optional)"
+                      error={getFieldError(field.state.meta.errors)}
+                    >
+                      <Select
+                        value={field.state.value}
+                        onValueChange={(value) =>
+                          field.handleChange(value ?? "")
+                        }
+                      >
+                        <option value="">Keep current</option>
+                        {model.divisions.map((div) => (
+                          <option key={div.id} value={div.id}>
+                            {div.name}
+                          </option>
+                        ))}
+                      </Select>
+                    </Field>
+                  )}
+                </approveForm.Field>
+              </CardContent>
+              <DialogFooter>
+                <DialogClose asChild>
+                  <Button type="button" variant="outline">
+                    Cancel
+                  </Button>
+                </DialogClose>
+                <Button type="submit" disabled={isReviewing}>
+                  {isReviewing ? "Approving..." : "Approve"}
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+
+        {/* Reject Registration Dialog */}
+        <Dialog open={rejectOpen} onOpenChange={handleRejectOpenChange}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Reject registration</DialogTitle>
+              <DialogDescription>
+                Are you sure you want to reject this registration? This action
+                cannot be undone.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button type="button" variant="outline">
+                  Cancel
+                </Button>
+              </DialogClose>
+              <Button
+                variant="outline"
+                disabled={isReviewing}
+                onClick={handleRejectConfirm}
+              >
+                {isReviewing ? "Rejecting..." : "Reject"}
               </Button>
             </DialogFooter>
           </DialogContent>
@@ -401,4 +1135,17 @@ export function CompetitionDetailScreen({
       </div>
     </main>
   );
+}
+
+function getFieldError(errors: unknown[]): string {
+  return errors
+    .map((err) => {
+      if (typeof err === "string") return err;
+      if (err && typeof err === "object" && "message" in err) {
+        return String((err as { message: unknown }).message);
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join(", ");
 }

--- a/apps/web/src/features/competition-detail/competition-detail-view-model.ts
+++ b/apps/web/src/features/competition-detail/competition-detail-view-model.ts
@@ -1,4 +1,11 @@
-import type { CategoryCollection, CategoryResponse } from "@padel/schemas";
+import type {
+  CategoryCollection,
+  CategoryResponse,
+  DivisionCollection,
+  DivisionResponse,
+  RegistrationCollection,
+  RegistrationResponse,
+} from "@padel/schemas";
 import type { TableRowState } from "@padel/ui";
 
 export interface CategoryRowViewModel {
@@ -9,10 +16,35 @@ export interface CategoryRowViewModel {
   rowState: TableRowState;
 }
 
+export interface DivisionRowViewModel {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+  rowState: TableRowState;
+}
+
+export interface RegistrationRowViewModel {
+  id: string;
+  participantId: string;
+  categoryId: string;
+  divisionId: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  rowState: TableRowState;
+}
+
 export interface CompetitionDetailPageViewModel {
   competitionId: string;
   categories: CategoryRowViewModel[];
   hasCategories: boolean;
+  divisions: DivisionRowViewModel[];
+  hasDivisions: boolean;
+  registrations: RegistrationRowViewModel[];
+  hasRegistrations: boolean;
+  pendingRegistrations: RegistrationRowViewModel[];
+  hasPendingRegistrations: boolean;
 }
 
 export function mapCategoriesToRowViewModel(
@@ -27,13 +59,53 @@ export function mapCategoriesToRowViewModel(
   }));
 }
 
+export function mapDivisionsToRowViewModel(
+  divisions: DivisionCollection,
+): DivisionRowViewModel[] {
+  return divisions.map((division: DivisionResponse) => ({
+    id: division.id,
+    name: division.name,
+    createdAt: division.createdAt,
+    updatedAt: division.updatedAt,
+    rowState: "default",
+  }));
+}
+
+export function mapRegistrationsToRowViewModel(
+  registrations: RegistrationCollection,
+): RegistrationRowViewModel[] {
+  return registrations.map((registration: RegistrationResponse) => ({
+    id: registration.id,
+    participantId: registration.participantId,
+    categoryId: registration.categoryId,
+    divisionId: registration.divisionId,
+    status: registration.status,
+    createdAt: registration.createdAt,
+    updatedAt: registration.updatedAt,
+    rowState: "default",
+  }));
+}
+
 export function mapToCompetitionDetailPageModel(
   competitionId: string,
   categories: CategoryCollection,
+  divisions: DivisionCollection,
+  registrations: RegistrationCollection,
 ): CompetitionDetailPageViewModel {
+  const registrationRows = mapRegistrationsToRowViewModel(registrations);
+  const pendingRegistrations = registrationRows.filter(
+    (r) => r.status === "pending_review",
+  );
+
   return {
     competitionId,
     categories: mapCategoriesToRowViewModel(categories),
     hasCategories: categories.length > 0,
+    divisions: mapDivisionsToRowViewModel(divisions),
+    hasDivisions: divisions.length > 0,
+    registrations: registrationRows,
+    hasRegistrations: registrations.length > 0,
+    pendingRegistrations,
+    hasPendingRegistrations: pendingRegistrations.length > 0,
   };
 }

--- a/apps/web/src/features/competition-detail/competition-divisions-query.ts
+++ b/apps/web/src/features/competition-detail/competition-divisions-query.ts
@@ -1,0 +1,22 @@
+import type { PadelApiClient } from "@padel/api-client";
+import { type QueryClient, queryOptions } from "@tanstack/react-query";
+
+export function competitionDivisionsQueryOptions(
+  apiClient: PadelApiClient,
+  competitionId: string,
+) {
+  return queryOptions({
+    queryKey: ["competitions", competitionId, "divisions"],
+    queryFn: ({ signal }) => apiClient.listDivisions(competitionId, { signal }),
+  });
+}
+
+export async function ensureCompetitionDivisions(
+  queryClient: QueryClient,
+  apiClient: PadelApiClient,
+  competitionId: string,
+) {
+  return queryClient.ensureQueryData(
+    competitionDivisionsQueryOptions(apiClient, competitionId),
+  );
+}

--- a/apps/web/src/features/competition-detail/competition-registrations-query.ts
+++ b/apps/web/src/features/competition-detail/competition-registrations-query.ts
@@ -1,0 +1,23 @@
+import type { PadelApiClient } from "@padel/api-client";
+import { type QueryClient, queryOptions } from "@tanstack/react-query";
+
+export function competitionRegistrationsQueryOptions(
+  apiClient: PadelApiClient,
+  competitionId: string,
+) {
+  return queryOptions({
+    queryKey: ["competitions", competitionId, "registrations"],
+    queryFn: ({ signal }) =>
+      apiClient.listRegistrations(competitionId, { signal }),
+  });
+}
+
+export async function ensureCompetitionRegistrations(
+  queryClient: QueryClient,
+  apiClient: PadelApiClient,
+  competitionId: string,
+) {
+  return queryClient.ensureQueryData(
+    competitionRegistrationsQueryOptions(apiClient, competitionId),
+  );
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -53,6 +53,14 @@ import {
 } from "./features/competition-detail/competition-categories-query.js";
 import { CompetitionDetailScreen } from "./features/competition-detail/competition-detail-screen.js";
 import { mapToCompetitionDetailPageModel } from "./features/competition-detail/competition-detail-view-model.js";
+import {
+  competitionDivisionsQueryOptions,
+  ensureCompetitionDivisions,
+} from "./features/competition-detail/competition-divisions-query.js";
+import {
+  competitionRegistrationsQueryOptions,
+  ensureCompetitionRegistrations,
+} from "./features/competition-detail/competition-registrations-query.js";
 import { CompetitionOperationsScreen } from "./features/competition-operations/competition-operations-screen.js";
 import { competitionOverviewQueryOptions } from "./features/competition-operations/competition-overview-query.js";
 import { mapCompetitionOverviewToPageModel } from "./features/competition-operations/competition-overview-view-model.js";
@@ -128,12 +136,26 @@ const competitionOperationsRoute = createRoute({
 const competitionDetailRoute = createRoute({
   getParentRoute: () => authenticatedRoute,
   path: "/competitions/$competitionId",
-  loader: ({ params, context }) =>
-    ensureCompetitionCategories(
-      context.queryClient,
-      context.apiClient,
-      params.competitionId,
-    ),
+  loader: async ({ params, context }) => {
+    const [categories, divisions, registrations] = await Promise.all([
+      ensureCompetitionCategories(
+        context.queryClient,
+        context.apiClient,
+        params.competitionId,
+      ),
+      ensureCompetitionDivisions(
+        context.queryClient,
+        context.apiClient,
+        params.competitionId,
+      ),
+      ensureCompetitionRegistrations(
+        context.queryClient,
+        context.apiClient,
+        params.competitionId,
+      ),
+    ]);
+    return { categories, divisions, registrations };
+  },
   pendingComponent: CompetitionDetailPending,
   pendingMs: 0,
   errorComponent: CompetitionDetailError,
@@ -677,13 +699,19 @@ function CompetitionOperationsError({ error }: ErrorComponentProps) {
 function CompetitionDetailRouteScreen() {
   const { apiClient, queryClient } = competitionDetailRoute.useRouteContext();
   const { competitionId } = competitionDetailRoute.useParams();
-  const { data } = useSuspenseQuery(
+  const { data: categories } = useSuspenseQuery(
     competitionCategoriesQueryOptions(apiClient, competitionId),
+  );
+  const { data: divisions } = useSuspenseQuery(
+    competitionDivisionsQueryOptions(apiClient, competitionId),
+  );
+  const { data: registrations } = useSuspenseQuery(
+    competitionRegistrationsQueryOptions(apiClient, competitionId),
   );
 
   const [error, setError] = useState<string | null>(null);
 
-  const createMutation = useMutation({
+  const createCategoryMutation = useMutation({
     mutationFn: (label: string) =>
       apiClient.createCategory(competitionId, { label }),
     onSuccess: () => {
@@ -696,7 +724,7 @@ function CompetitionDetailRouteScreen() {
     },
   });
 
-  const updateMutation = useMutation({
+  const updateCategoryMutation = useMutation({
     mutationFn: ({ id, label }: { id: string; label: string }) =>
       apiClient.updateCategory(competitionId, id, { label }),
     onSuccess: () => {
@@ -709,7 +737,7 @@ function CompetitionDetailRouteScreen() {
     },
   });
 
-  const deleteMutation = useMutation({
+  const deleteCategoryMutation = useMutation({
     mutationFn: (id: string) => apiClient.deleteCategory(competitionId, id),
     onSuccess: () => {
       queryClient.invalidateQueries({
@@ -723,21 +751,158 @@ function CompetitionDetailRouteScreen() {
     },
   });
 
+  const createDivisionMutation = useMutation({
+    mutationFn: (name: string) =>
+      apiClient.createDivision(competitionId, { name }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["competitions", competitionId, "divisions"],
+      });
+    },
+    onError: () => {
+      setError("Failed to create division. Please try again.");
+    },
+  });
+
+  const updateDivisionMutation = useMutation({
+    mutationFn: ({ id, name }: { id: string; name: string }) =>
+      apiClient.updateDivision(competitionId, id, { name }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["competitions", competitionId, "divisions"],
+      });
+    },
+    onError: () => {
+      setError("Failed to update division. Please try again.");
+    },
+  });
+
+  const deleteDivisionMutation = useMutation({
+    mutationFn: (id: string) => apiClient.deleteDivision(competitionId, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["competitions", competitionId, "divisions"],
+      });
+    },
+    onError: () => {
+      setError(
+        "Failed to delete division. It may be referenced by registrations.",
+      );
+    },
+  });
+
+  const createRegistrationMutation = useMutation({
+    mutationFn: ({
+      categoryId,
+      divisionId,
+    }: {
+      categoryId: string;
+      divisionId: string;
+    }) =>
+      apiClient.createRegistration(competitionId, { categoryId, divisionId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["competitions", competitionId, "registrations"],
+      });
+    },
+    onError: () => {
+      setError("Failed to register. Please try again.");
+    },
+  });
+
+  const approveRegistrationMutation = useMutation({
+    mutationFn: ({
+      registrationId,
+      categoryId,
+      divisionId,
+    }: {
+      registrationId: string;
+      categoryId?: string;
+      divisionId?: string;
+    }) =>
+      apiClient.approveRegistration(competitionId, registrationId, {
+        categoryId,
+        divisionId,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["competitions", competitionId, "registrations"],
+      });
+    },
+    onError: () => {
+      setError("Failed to approve registration. Please try again.");
+    },
+  });
+
+  const rejectRegistrationMutation = useMutation({
+    mutationFn: (registrationId: string) =>
+      apiClient.rejectRegistration(competitionId, registrationId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["competitions", competitionId, "registrations"],
+      });
+    },
+    onError: () => {
+      setError("Failed to reject registration. Please try again.");
+    },
+  });
+
   return (
     <CompetitionDetailScreen
-      model={mapToCompetitionDetailPageModel(competitionId, data)}
+      model={mapToCompetitionDetailPageModel(
+        competitionId,
+        categories,
+        divisions,
+        registrations,
+      )}
       onCreateCategory={async (label) => {
-        await createMutation.mutateAsync(label);
+        await createCategoryMutation.mutateAsync(label);
       }}
       onUpdateCategory={async (id, label) => {
-        await updateMutation.mutateAsync({ id, label });
+        await updateCategoryMutation.mutateAsync({ id, label });
       }}
       onDeleteCategory={async (id) => {
-        await deleteMutation.mutateAsync(id);
+        await deleteCategoryMutation.mutateAsync(id);
       }}
-      isCreating={createMutation.isPending}
-      isUpdating={updateMutation.isPending}
-      isDeleting={deleteMutation.isPending}
+      onCreateDivision={async (name) => {
+        await createDivisionMutation.mutateAsync(name);
+      }}
+      onUpdateDivision={async (id, name) => {
+        await updateDivisionMutation.mutateAsync({ id, name });
+      }}
+      onDeleteDivision={async (id) => {
+        await deleteDivisionMutation.mutateAsync(id);
+      }}
+      onCreateRegistration={async (categoryId, divisionId) => {
+        await createRegistrationMutation.mutateAsync({
+          categoryId,
+          divisionId,
+        });
+      }}
+      onApproveRegistration={async (registrationId, categoryId, divisionId) => {
+        await approveRegistrationMutation.mutateAsync({
+          registrationId,
+          categoryId,
+          divisionId,
+        });
+      }}
+      onRejectRegistration={async (registrationId) => {
+        await rejectRegistrationMutation.mutateAsync(registrationId);
+      }}
+      isCreating={
+        createCategoryMutation.isPending || createDivisionMutation.isPending
+      }
+      isUpdating={
+        updateCategoryMutation.isPending || updateDivisionMutation.isPending
+      }
+      isDeleting={
+        deleteCategoryMutation.isPending || deleteDivisionMutation.isPending
+      }
+      isRegistering={createRegistrationMutation.isPending}
+      isReviewing={
+        approveRegistrationMutation.isPending ||
+        rejectRegistrationMutation.isPending
+      }
       error={error}
       clearError={() => setError(null)}
     />

--- a/docs/09-agile/product-backlog.md
+++ b/docs/09-agile/product-backlog.md
@@ -692,7 +692,7 @@ For each ticket, include:
   - integration: verify the repository adapter against real PostgreSQL and verify the HTTP endpoints through NestJS adapter tests
   - e2e/manual: n/a until a frontend category management UI is delivered
 - estimate: `M`
-- status: `approved`
+- status: `done`
 - implementation workflow: `backend`
 - GitHub labels: `type:task`, `lane:backend`, `area:backend`, `area:competition`, `target:apps-api`, `target:packages-schemas`
 - milestone/sprint: `competition-structure-sprint`
@@ -732,7 +732,7 @@ For each ticket, include:
   - integration: verify the repository adapter against real PostgreSQL and verify the HTTP endpoints through NestJS adapter tests
   - e2e/manual: n/a until a frontend division management UI is delivered
 - estimate: `M`
-- status: `approved`
+- status: `done`
 - implementation workflow: `backend`
 - GitHub labels: `type:task`, `lane:backend`, `area:backend`, `area:competition`, `target:apps-api`, `target:packages-schemas`
 - milestone/sprint: `competition-structure-sprint`
@@ -774,7 +774,7 @@ For each ticket, include:
   - integration: verify the repository adapter against real PostgreSQL and verify the HTTP endpoint through NestJS adapter tests
   - e2e/manual: n/a until a frontend registration UI is delivered
 - estimate: `M`
-- status: `approved`
+- status: `done`
 - implementation workflow: `backend`
 - GitHub labels: `type:task`, `lane:backend`, `area:backend`, `area:competition`, `area:registration`, `target:apps-api`, `target:packages-schemas`
 - milestone/sprint: `competition-structure-sprint`
@@ -814,10 +814,10 @@ For each ticket, include:
   - integration: verify the repository adapter against real PostgreSQL and verify the HTTP endpoints through NestJS adapter tests
   - e2e/manual: n/a until a frontend registration review UI is delivered
 - estimate: `M`
-- status: `approved`
+- status: `done`
 - implementation workflow: `backend`
 - GitHub labels: `type:task`, `lane:backend`, `area:backend`, `area:competition`, `area:registration`, `target:apps-api`, `target:packages-schemas`
-- milestone/sprint: `competition-structure-sprint`
+- milestone/sprint: `registration-completion-sprint`
 - GitHub issue URL or placeholder: `https://github.com/Damimd10/padel/issues/54`
 
 ### TKT-051 - Build frontend competition detail with category and division management
@@ -851,10 +851,10 @@ For each ticket, include:
   - integration: verify the route layer composes typed API clients with shared UI primitives without boundary leaks
   - e2e/manual: confirm an administrator can create, edit, and delete categories and divisions through the real frontend flow
 - estimate: `M`
-- status: `approved`
+- status: `done`
 - implementation workflow: `frontend`
 - GitHub labels: `type:task`, `lane:frontend`, `area:frontend`, `area:competition`, `target:apps-web`, `target:packages-api-client`, `target:packages-ui`
-- milestone/sprint: `competition-structure-sprint`
+- milestone/sprint: `registration-completion-sprint`
 - GitHub issue URL or placeholder: `https://github.com/Damimd10/padel/issues/51`
 
 ### TKT-052 - Build frontend participant registration flow
@@ -889,10 +889,10 @@ For each ticket, include:
   - integration: verify the route layer composes typed API clients with shared UI primitives without boundary leaks
   - e2e/manual: confirm a player can register for an open competition through the real frontend flow
 - estimate: `M`
-- status: `approved`
+- status: `done`
 - implementation workflow: `frontend`
 - GitHub labels: `type:task`, `lane:frontend`, `area:frontend`, `area:competition`, `area:registration`, `target:apps-web`, `target:packages-api-client`, `target:packages-ui`
-- milestone/sprint: `competition-structure-sprint`
+- milestone/sprint: `registration-completion-sprint`
 - GitHub issue URL or placeholder: `https://github.com/Damimd10/padel/issues/53`
 
 ### TKT-053 - Build frontend registration review and approval UI
@@ -926,8 +926,8 @@ For each ticket, include:
   - integration: verify the route layer composes typed API clients with shared UI primitives without boundary leaks
   - e2e/manual: confirm an administrator can review, approve, and reject registrations through the real frontend flow
 - estimate: `M`
-- status: `approved`
+- status: `done`
 - implementation workflow: `frontend`
 - GitHub labels: `type:task`, `lane:frontend`, `area:frontend`, `area:competition`, `area:registration`, `target:apps-web`, `target:packages-api-client`, `target:packages-ui`
-- milestone/sprint: `competition-structure-sprint`
+- milestone/sprint: `registration-completion-sprint`
 - GitHub issue URL or placeholder: `https://github.com/Damimd10/padel/issues/55`

--- a/docs/09-agile/sprint-backlog.md
+++ b/docs/09-agile/sprint-backlog.md
@@ -36,69 +36,22 @@ If this document and the GitHub Project disagree, update both and record the rea
 - `TKT-043` is delivered: backend self-service auth contracts for sign-up, sign-in, sign-out, session, forget-password, and reset-password are implemented in `apps/api` with schemas in `packages/schemas`.
 - `TKT-045` (backend forgot-password and reset-password flows) and `TKT-046` (frontend forgot-password and reset-password screens) are delivered as part of the auth self-service sprint.
 - Both `next-ui-package-sprint` and `auth-self-service-foundation-sprint` milestones are complete.
-- `TKT-047` through `TKT-053` are the new approved backlog items for the `competition-structure-sprint`, covering category management, division management, participant registration, and their frontend UIs.
 
-## Active Sprint Record
+## Completed Sprint: `competition-structure-sprint`
 
-- ticket ID and title: `TKT-047` - Add backend category management endpoints for competitions
-- delivery lane: `backend`
-- affected apps/packages: `apps/api`, `packages/schemas`
-- owner: `unassigned`
-- GitHub issue link: `https://github.com/Damimd10/padel/issues/49`
-- current project status: `In Sprint`
-- blocked/unblocked state: `unblocked`
-- notes for carryover risk: `none; depends on delivered Competition aggregate (TKT-014) and authenticated boundary (TKT-017)`
+- `TKT-047` — **DONE**: Category CRUD endpoints delivered (PR #56). Domain, use cases, controller, Prisma repo, schemas, tests all present.
+- `TKT-048` — **DONE**: Division CRUD endpoints delivered (PR #58). Domain, use cases, controller, Prisma repo, schemas, tests all present.
+- `TKT-049` — **DONE**: Registration aggregate + create + list delivered (PR #60). Status changed to `pending_review` on creation. Validation for competition state and category/division existence added.
+- `TKT-050` — **DONE**: Registration review/approve/reject endpoints delivered. Status transition use cases, HTTP endpoints, and schemas implemented.
+- `TKT-051` — **DONE**: Competition detail page with category and division management UI delivered. Division CRUD, registration form, and registration review UI included.
+- `TKT-052` — **DONE**: Frontend participant registration flow delivered. Registration form with category/division selection, typed API client wrappers, and success/error states.
+- `TKT-053` — **DONE**: Frontend registration review and approval UI delivered. Table-based review view, approve/reject actions with category/division adjustment, admin-only access.
 
-- ticket ID and title: `TKT-048` - Add backend division management endpoints for competitions
-- delivery lane: `backend`
-- affected apps/packages: `apps/api`, `packages/schemas`
-- owner: `unassigned`
-- GitHub issue link: `https://github.com/Damimd10/padel/issues/50`
-- current project status: `In Sprint`
-- blocked/unblocked state: `unblocked`
-- notes for carryover risk: `none; depends on delivered Competition aggregate (TKT-014) and authenticated boundary (TKT-017)`
+## Active Sprint Record: `registration-completion-sprint`
 
-- ticket ID and title: `TKT-049` - Add backend participant registration endpoint for competitions
-- delivery lane: `backend`
-- affected apps/packages: `apps/api`, `packages/schemas`
-- owner: `unassigned`
-- GitHub issue link: `https://github.com/Damimd10/padel/issues/52`
-- current project status: `Planned`
-- blocked/unblocked state: `depends on TKT-047 and TKT-048`
-- notes for carryover risk: `registration requires categories and divisions to exist before it can validate category/division assignment`
+All tickets from the `competition-structure-sprint` have been completed and merged. The registration lifecycle is now fully implemented end-to-end:
 
-- ticket ID and title: `TKT-050` - Add backend registration review, approval, and rejection endpoints
-- delivery lane: `backend`
-- affected apps/packages: `apps/api`, `packages/schemas`
-- owner: `unassigned`
-- GitHub issue link: `https://github.com/Damimd10/padel/issues/54`
-- current project status: `Planned`
-- blocked/unblocked state: `depends on TKT-049`
-- notes for carryover risk: `review workflow requires registrations to exist first`
-
-- ticket ID and title: `TKT-051` - Build frontend competition detail page with category and division management UI
-- delivery lane: `frontend`
-- affected apps/packages: `apps/web`, `packages/api-client`, `packages/ui`
-- owner: `unassigned`
-- GitHub issue link: `https://github.com/Damimd10/padel/issues/51`
-- current project status: `Planned`
-- blocked/unblocked state: `depends on TKT-047 and TKT-048`
-- notes for carryover risk: `frontend UI requires backend category and division contracts to be stable`
-
-- ticket ID and title: `TKT-052` - Build frontend participant registration flow for competitions
-- delivery lane: `frontend`
-- affected apps/packages: `apps/web`, `packages/api-client`, `packages/ui`
-- owner: `unassigned`
-- GitHub issue link: `https://github.com/Damimd10/padel/issues/53`
-- current project status: `Planned`
-- blocked/unblocked state: `depends on TKT-047, TKT-048, and TKT-049`
-- notes for carryover risk: `registration form requires categories, divisions, and registration endpoint to exist`
-
-- ticket ID and title: `TKT-053` - Build frontend registration review and approval UI for competition administrators
-- delivery lane: `frontend`
-- affected apps/packages: `apps/web`, `packages/api-client`, `packages/ui`
-- owner: `unassigned`
-- GitHub issue link: `https://github.com/Damimd10/padel/issues/55`
-- current project status: `Planned`
-- blocked/unblocked state: `depends on TKT-049 and TKT-050`
-- notes for carryover risk: `review UI requires registration submission and review endpoints to exist`
+- Players can self-register for competitions in `open` status
+- Registrations start in `pending_review` status
+- Administrators can approve (with optional category/division adjustment) or reject registrations
+- Competition detail page shows categories, divisions, registration form, and pending registrations for review

--- a/docs/09-agile/sprint-plan.md
+++ b/docs/09-agile/sprint-plan.md
@@ -43,33 +43,40 @@ Every committed ticket must:
 - stretch tickets delivered: `TKT-043`, `TKT-045`, `TKT-046`
 - exit criteria met: sign-in, sign-up, forget-password, and reset-password routes implemented with typed auth client wrappers, guest-only redirect behavior, and authenticated route protection
 
-## Next Sprint Recommendation
+### Sprint: `competition-structure-sprint` (COMPLETED)
 
 - sprint goal: expand the competition operations surface with category and division management so organizers can configure the full structure needed for participant registration and match scheduling
-- sprint dates or iteration label: `competition-structure-sprint`
+- committed tickets: `TKT-047`, `TKT-048`
+- stretch tickets delivered: `TKT-049`, `TKT-050`, `TKT-051`, `TKT-052`, `TKT-053`
+- exit criteria met: category and division management endpoints landed with hexagonal architecture compliance, schema contracts, and integration tests. Registration lifecycle fully implemented end-to-end: players can self-register, administrators can review/approve/reject, and competition detail page shows full management UI.
+
+## Next Sprint Recommendation
+
+- sprint goal: implement match scheduling and result entry workflows so competitions can progress from registration through to completion
+- sprint dates or iteration label: `match-scheduling-sprint`
 - capacity assumptions:
-  - the Better Auth runtime, frontend auth routes, and all shared UI primitives are delivered on `master`
-  - competition creation is protected with authenticated identity (`TKT-017`)
-  - the competition operations overview scaffold is in place but lacks category, division, and registration workflows
-  - the shared UI package has table foundations, form primitives, feedback components, and date/numeric inputs ready for composition
+  - registration lifecycle is fully implemented end-to-end
+  - competition detail page shows categories, divisions, registrations, and review UI
+  - shared UI package has all primitives needed for forms, tables, feedback, and overlays
+  - competition status transitions (draft -> open -> closed) need to be implemented
 - recommended committed tickets:
-  - new backend ticket: add category management under an existing competition (epic `STRUC-01`)
-  - new backend ticket: add division management under an existing competition (epic `STRUC-01`)
-- recommended stretch tickets:
-  - new frontend ticket: competition detail page with category and division management UI
-  - new backend ticket: participant registration endpoint (epic `REG-01`)
+  - competition status transitions (backend): allow organizers to open/close competitions
+  - match creation and scheduling (backend): generate matches from approved registrations
+  - match result entry (backend + frontend): allow organizers to record match results
 - lane balance across frontend / backend / infrastructure:
-  - backend: category and division management slices are the highest-value next step to unlock registration and scheduling
-  - frontend: a competition detail page should follow once the backend contracts land
-  - infrastructure: no additional infrastructure work required
+  - backend: status transitions, match generation, result persistence
+  - frontend: match scheduling UI, result entry forms, bracket/standings display
+  - infrastructure: no additional work required
 - affected apps/packages summary:
-  - new category/division backend tickets: `apps/api`, `packages/schemas`
-  - new competition detail frontend ticket: `apps/web`, `packages/api-client`, `packages/ui`
+  - backend: `apps/api`, `packages/schemas`
+  - frontend: `apps/web`, `packages/api-client`, `packages/ui`
 - dependencies and blockers:
-  - category and division management depend on the delivered Competition aggregate (`TKT-014`) and authenticated boundary (`TKT-017`)
-  - frontend competition detail depends on backend category/division contracts landing first
+  - match generation depends on approved registrations existing
+  - result entry depends on matches being created
 - GitHub milestone / project view used for execution:
-  - new milestone: `competition-structure-sprint`
+  - new milestone: `match-scheduling-sprint`
 - exit criteria:
-  - category and division management endpoints land with hexagonal architecture compliance, schema contracts in `packages/schemas`, and integration tests against PostgreSQL
-  - GitHub execution state stays synced so the sprint doc, issue metadata, and project board all reflect the same committed work
+  - organizers can open/close competitions to control registration windows
+  - matches can be generated from approved registrations
+  - results can be recorded and displayed
+  - all endpoints have hexagonal architecture compliance, schema contracts, and integration tests

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -5,20 +5,32 @@ import {
   type CategoryResponse,
   type CompetitionOverviewCollection,
   type CreateCategoryRequest,
+  type CreateDivisionRequest,
+  type CreateRegistrationRequest,
+  type DivisionCollection,
+  type DivisionResponse,
   type ForgetPasswordRequest,
   type ForgetPasswordResponse,
+  type RegistrationCollection,
+  type RegistrationResponse,
   type ResetPasswordRequest,
   type ResetPasswordResponse,
+  type ReviewRegistrationRequest,
   type SignInWithEmailRequest,
   type SignOutResponse,
   type SignUpWithEmailRequest,
   type UpdateCategoryRequest,
+  type UpdateDivisionRequest,
   authMutationResponseSchema,
   authSessionResponseSchema,
   categoryCollectionSchema,
   categoryResponseSchema,
   competitionOverviewCollectionSchema,
+  divisionCollectionSchema,
+  divisionResponseSchema,
   forgetPasswordResponseSchema,
+  registrationCollectionSchema,
+  registrationResponseSchema,
   resetPasswordResponseSchema,
   signOutResponseSchema,
 } from "@padel/schemas";
@@ -42,6 +54,35 @@ export function competitionCategoryPath(
   categoryId: string,
 ) {
   return `/competitions/${competitionId}/categories/${categoryId}`;
+}
+
+export function competitionDivisionsPath(competitionId: string) {
+  return `/competitions/${competitionId}/divisions`;
+}
+
+export function competitionDivisionPath(
+  competitionId: string,
+  divisionId: string,
+) {
+  return `/competitions/${competitionId}/divisions/${divisionId}`;
+}
+
+export function competitionRegistrationsPath(competitionId: string) {
+  return `/competitions/${competitionId}/registrations`;
+}
+
+export function competitionRegistrationApprovePath(
+  competitionId: string,
+  registrationId: string,
+) {
+  return `/competitions/${competitionId}/registrations/${registrationId}/approve`;
+}
+
+export function competitionRegistrationRejectPath(
+  competitionId: string,
+  registrationId: string,
+) {
+  return `/competitions/${competitionId}/registrations/${registrationId}/reject`;
 }
 
 export class ApiClientError extends Error {
@@ -72,6 +113,34 @@ export interface UpdateCategoryRequestOptions {
 }
 
 export interface DeleteCategoryRequestOptions {
+  signal?: AbortSignal;
+}
+
+export interface ListDivisionsRequestOptions {
+  signal?: AbortSignal;
+}
+
+export interface CreateDivisionRequestOptions {
+  signal?: AbortSignal;
+}
+
+export interface UpdateDivisionRequestOptions {
+  signal?: AbortSignal;
+}
+
+export interface DeleteDivisionRequestOptions {
+  signal?: AbortSignal;
+}
+
+export interface ListRegistrationsRequestOptions {
+  signal?: AbortSignal;
+}
+
+export interface CreateRegistrationRequestOptions {
+  signal?: AbortSignal;
+}
+
+export interface ReviewRegistrationRequestOptions {
   signal?: AbortSignal;
 }
 
@@ -125,6 +194,54 @@ export interface PadelApiClient {
     categoryId: string,
     options?: DeleteCategoryRequestOptions,
   ): Promise<void>;
+
+  listDivisions(
+    competitionId: string,
+    options?: ListDivisionsRequestOptions,
+  ): Promise<DivisionCollection>;
+
+  createDivision(
+    competitionId: string,
+    request: CreateDivisionRequest,
+    options?: CreateDivisionRequestOptions,
+  ): Promise<DivisionResponse>;
+
+  updateDivision(
+    competitionId: string,
+    divisionId: string,
+    request: UpdateDivisionRequest,
+    options?: UpdateDivisionRequestOptions,
+  ): Promise<DivisionResponse>;
+
+  deleteDivision(
+    competitionId: string,
+    divisionId: string,
+    options?: DeleteDivisionRequestOptions,
+  ): Promise<void>;
+
+  listRegistrations(
+    competitionId: string,
+    options?: ListRegistrationsRequestOptions,
+  ): Promise<RegistrationCollection>;
+
+  createRegistration(
+    competitionId: string,
+    request: CreateRegistrationRequest,
+    options?: CreateRegistrationRequestOptions,
+  ): Promise<RegistrationResponse>;
+
+  approveRegistration(
+    competitionId: string,
+    registrationId: string,
+    request?: ReviewRegistrationRequest,
+    options?: ReviewRegistrationRequestOptions,
+  ): Promise<RegistrationResponse>;
+
+  rejectRegistration(
+    competitionId: string,
+    registrationId: string,
+    options?: ReviewRegistrationRequestOptions,
+  ): Promise<RegistrationResponse>;
 }
 
 function parseResponseWithSchema<T>(
@@ -237,6 +354,81 @@ export function createApiClient({
       await client.delete(competitionCategoryPath(competitionId, categoryId), {
         signal: options.signal,
       });
+    },
+
+    async listDivisions(competitionId, options = {}) {
+      const response = await client.get(
+        competitionDivisionsPath(competitionId),
+        { signal: options.signal },
+      );
+      return parseResponseWithSchema(response.data, divisionCollectionSchema);
+    },
+
+    async createDivision(competitionId, request, options = {}) {
+      const response = await client.post(
+        competitionDivisionsPath(competitionId),
+        request,
+        { signal: options.signal },
+      );
+      return parseResponseWithSchema(response.data, divisionResponseSchema);
+    },
+
+    async updateDivision(competitionId, divisionId, request, options = {}) {
+      const response = await client.patch(
+        competitionDivisionPath(competitionId, divisionId),
+        request,
+        { signal: options.signal },
+      );
+      return parseResponseWithSchema(response.data, divisionResponseSchema);
+    },
+
+    async deleteDivision(competitionId, divisionId, options = {}) {
+      await client.delete(competitionDivisionPath(competitionId, divisionId), {
+        signal: options.signal,
+      });
+    },
+
+    async listRegistrations(competitionId, options = {}) {
+      const response = await client.get(
+        competitionRegistrationsPath(competitionId),
+        { signal: options.signal },
+      );
+      return parseResponseWithSchema(
+        response.data,
+        registrationCollectionSchema,
+      );
+    },
+
+    async createRegistration(competitionId, request, options = {}) {
+      const response = await client.post(
+        competitionRegistrationsPath(competitionId),
+        request,
+        { signal: options.signal },
+      );
+      return parseResponseWithSchema(response.data, registrationResponseSchema);
+    },
+
+    async approveRegistration(
+      competitionId,
+      registrationId,
+      request = {},
+      options = {},
+    ) {
+      const response = await client.patch(
+        competitionRegistrationApprovePath(competitionId, registrationId),
+        request,
+        { signal: options.signal },
+      );
+      return parseResponseWithSchema(response.data, registrationResponseSchema);
+    },
+
+    async rejectRegistration(competitionId, registrationId, options = {}) {
+      const response = await client.patch(
+        competitionRegistrationRejectPath(competitionId, registrationId),
+        {},
+        { signal: options.signal },
+      );
+      return parseResponseWithSchema(response.data, registrationResponseSchema);
     },
   };
 }

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -291,10 +291,20 @@ export const registrationResponseSchema = z
 
 export const registrationCollectionSchema = z.array(registrationResponseSchema);
 
+export const reviewRegistrationRequestSchema = z
+  .object({
+    categoryId: z.string().uuid().optional(),
+    divisionId: z.string().uuid().optional(),
+  })
+  .strict();
+
 export type CreateRegistrationRequest = z.infer<
   typeof createRegistrationRequestSchema
 >;
 export type RegistrationResponse = z.infer<typeof registrationResponseSchema>;
 export type RegistrationCollection = z.infer<
   typeof registrationCollectionSchema
+>;
+export type ReviewRegistrationRequest = z.infer<
+  typeof reviewRegistrationRequestSchema
 >;


### PR DESCRIPTION
## Summary

- **TKT-054**: Add registration validation for competition status and category/division existence
- **TKT-050**: Add backend registration review/approve/reject endpoints with status transitions
- **TKT-055**: Complete competition detail page with division management and registration review UI
- **TKT-052**: Add frontend participant registration flow with category/division selection
- **TKT-053**: Add frontend registration review and approval UI for administrators

## Backend Changes

- `CompetitionRegistration` aggregate: status starts as `pending_review`, adds `approve()`, `reject()`, `withdraw()` methods with status transition validation
- `CreateRegistrationUseCase`: validates competition is `open`, category/division exist in target competition
- New `ApproveRegistrationUseCase` and `RejectRegistrationUseCase`
- `RegistrationController`: `PATCH :registrationId/approve` and `PATCH :registrationId/reject` endpoints
- `CompetitionRepository`: added `findById()` method
- `RegistrationRepository`: added `update()` method

## Frontend Changes

- Competition detail page: division CRUD, registration form, pending registrations review table
- New query hooks: `competition-divisions-query.ts`, `competition-registrations-query.ts`
- API client: division and registration methods (`listDivisions`, `createDivision`, `updateDivision`, `deleteDivision`, `listRegistrations`, `createRegistration`, `approveRegistration`, `rejectRegistration`)
- Schemas: `reviewRegistrationRequestSchema` added

## Documentation

- Updated `product-backlog.md`, `sprint-backlog.md`, `sprint-plan.md`

## Verification

- 71 tests passing
- Lint and typecheck passing
- Pre-commit and pre-push hooks validated